### PR TITLE
MOSIP-26634 : Pom changes for rc1 release of P2

### DIFF
--- a/id-repository/credential-request-generator/pom.xml
+++ b/id-repository/credential-request-generator/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>io.mosip.idrepository</groupId>
 		<artifactId>id-repository-parent</artifactId>
-		<version>1.1.5.5-P1-rc1</version>
+		<version>1.1.5.5-P2-rc1</version>
 	</parent>
 
 	<artifactId>credential-request-generator</artifactId>
-	<version>1.1.5.5-P1-rc1</version>
+	<version>1.1.5.5-P2-rc1</version>
 	<name>credential-request-generator</name>
 
 	<properties>

--- a/id-repository/credential-service/pom.xml
+++ b/id-repository/credential-service/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>io.mosip.idrepository</groupId>
     <artifactId>id-repository-parent</artifactId>
-    <version>1.1.5.5-P1-rc1</version>
+    <version>1.1.5.5-P2-rc1</version>
   </parent>
   <groupId>io.mosip.idrepository</groupId>
   <artifactId>credential-service</artifactId>
-  <version>1.1.5.5-P1-rc1</version>
+  <version>1.1.5.5-P2-rc1</version>
   <name>credential-service</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/id-repository/id-repository-core/pom.xml
+++ b/id-repository/id-repository-core/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>io.mosip.idrepository</groupId>
 		<artifactId>id-repository-parent</artifactId>
-		<version>1.1.5.5-P1-rc1</version>
+		<version>1.1.5.5-P2-rc1</version>
 	</parent>
 
 	<artifactId>id-repository-core</artifactId>
-	<version>1.1.5.5-P1-rc1</version>
+	<version>1.1.5.5-P2-rc1</version>
 	<name>idrepo-core</name>
 	<description>ID-Repository core</description>
 

--- a/id-repository/id-repository-identity-service/pom.xml
+++ b/id-repository/id-repository-identity-service/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>io.mosip.idrepository</groupId>
 		<artifactId>id-repository-parent</artifactId>
-		<version>1.1.5.5-P1</version>
+		<version>1.1.5.5-P2-rc1</version>
 	</parent>
 
 	<artifactId>id-repository-identity-service</artifactId>
-	<version>1.1.5.5-P1</version>
+	<version>1.1.5.5-P2-rc1</version>
 	<name>identity-service</name>
 	<description>ID-Repository Identity service</description>
 

--- a/id-repository/id-repository-salt-generator/pom.xml
+++ b/id-repository/id-repository-salt-generator/pom.xml
@@ -3,13 +3,13 @@
 	<modelVersion>4.0.0</modelVersion>
     <groupId>io.mosip.idrepository</groupId>
 	<artifactId>id-repository-salt-generator</artifactId>
-	<version>1.1.5.5-P1-rc1</version>
+	<version>1.1.5.5</version>
 	<name>ID-Repository Salt Generator</name>
 	
 	<parent>
 		<groupId>io.mosip.idrepository</groupId>
 		<artifactId>id-repository-parent</artifactId>
-		<version>1.1.5.5-P1-rc1</version>
+		<version>1.1.5.5</version>
 	</parent>
 	
 	<description>Batch Job Application to for one-time populating of salt values for ID Repository salt tables.</description>

--- a/id-repository/id-repository-vid-service/pom.xml
+++ b/id-repository/id-repository-vid-service/pom.xml
@@ -5,10 +5,10 @@
 	<parent>
 		<groupId>io.mosip.idrepository</groupId>
 		<artifactId>id-repository-parent</artifactId>
-		<version>1.1.5.5-P1-rc1</version>
+		<version>1.1.5.5-P2-rc1</version>
 	</parent>
 	<artifactId>id-repository-vid-service</artifactId>
-	<version>1.1.5.5-P1-rc1</version>
+	<version>1.1.5.5-P2-rc1</version>
 	<name>vid-service</name>
 	<description>ID-Repository Virtual ID Service</description>
 

--- a/id-repository/pom.xml
+++ b/id-repository/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.idrepository</groupId>
 	<artifactId>id-repository-parent</artifactId>
-	<version>1.1.5.5-P1</version>
+	<version>1.1.5.5-P2-rc1</version>
 	<packaging>pom</packaging>
 
 	<name>ID-Repository</name>
@@ -57,16 +57,16 @@
 	</repositories>
 
 	<modules>
- <!--	<module>id-repository-core</module>
- 	<module>id-repository-vid-service</module> -->
+	<module>id-repository-core</module>
+ 	<module>id-repository-vid-service</module>
  	<module>id-repository-identity-service</module>
-<!--	<module>credential-request-generator</module>
+	<module>credential-request-generator</module>
 	<module>credential-service</module>
-	<module>id-repository-salt-generator</module> -->
+<!--	<module>id-repository-salt-generator</module> -->
 	</modules>
 
 	<properties>
-		<id.repository.core.version>1.1.5.5-P1-rc1</id.repository.core.version>
+		<id.repository.core.version>1.1.5.5-P2-rc1</id.repository.core.version>
 		<!-- maven -->
 		<maven.jar.plugin.version>3.0.2</maven.jar.plugin.version>
 		<maven.war.plugin.version>3.1.0</maven.war.plugin.version>


### PR DESCRIPTION
Many modules are built again in this patch P2 since they were changes in P1 but not released correctly
Since there was no change salt generator after 1.1.5.5, the version is also changed to 1.1.5.5 and excluded from build