### PR TITLE
Enabled salt generator module in build to be included in next release

### DIFF
--- a/id-repository/pom.xml
+++ b/id-repository/pom.xml
@@ -62,7 +62,7 @@
  	<module>id-repository-identity-service</module>
 	<module>credential-request-generator</module>
 	<module>credential-service</module>
-<!--	<module>id-repository-salt-generator</module> -->
+	<module>id-repository-salt-generator</module>
 	</modules>
 
 	<properties>


### PR DESCRIPTION
Found that last released version of salt generator is 1.1.5.5, but mosipid and mosipint docker images were not found. Since salt generator was the only module not part of the current hotfix release and to simplify deployment, rebuilding of salt generator is enabled.