### PR TITLE
MOSIP-39719 - Added a log level for the commons classes

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testrunner/MosipTestRunner.java
@@ -25,6 +25,7 @@ import com.nimbusds.jose.jwk.RSAKey;
 import io.mosip.testrig.apirig.dataprovider.BiometricDataProvider;
 import io.mosip.testrig.apirig.dbaccess.DBManager;
 import io.mosip.testrig.apirig.idrepo.utils.IdRepoConfigManager;
+import io.mosip.testrig.apirig.idrepo.utils.IdRepoUtil;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.testrunner.ExtractResource;
 import io.mosip.testrig.apirig.testrunner.HealthChecker;
@@ -34,6 +35,7 @@ import io.mosip.testrig.apirig.utils.AuthTestsUtil;
 import io.mosip.testrig.apirig.utils.CertsUtil;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.JWKKeyUtil;
+import io.mosip.testrig.apirig.utils.KernelAuthentication;
 import io.mosip.testrig.apirig.utils.KeyCloakUserAndAPIKeyGeneration;
 import io.mosip.testrig.apirig.utils.KeycloakUserManager;
 import io.mosip.testrig.apirig.utils.MispPartnerAndLicenseKeyGeneration;
@@ -62,12 +64,8 @@ public class MosipTestRunner {
 	public static void main(String[] arg) {
 
 		try {
+			LOGGER.info("** ------------- API Test Rig Run Started --------------------------------------------- **");
 
-			Map<String, String> envMap = System.getenv();
-			LOGGER.info("** ------------- Get ALL ENV varibales --------------------------------------------- **");
-			for (String envName : envMap.keySet()) {
-				LOGGER.info(String.format("ENV %s = %s%n", envName, envMap.get(envName)));
-			}
 			BaseTestCase.setRunContext(getRunType(), jarUrl);
 			ExtractResource.removeOldMosipTestTestResource();
 			if (getRunType().equalsIgnoreCase("JAR")) {
@@ -158,6 +156,9 @@ public class MosipTestRunner {
 		MispPartnerAndLicenseKeyGeneration.setLogLevel();
 		JWKKeyUtil.setLogLevel();
 		CertsUtil.setLogLevel();
+		KernelAuthentication.setLogLevel();
+		BaseTestCase.setLogLevel();
+		IdRepoUtil.setLogLevel();
 	}
 
 	/**

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testrunner/MosipTestRunner.java
@@ -34,6 +34,7 @@ import io.mosip.testrig.apirig.utils.AdminTestUtil;
 import io.mosip.testrig.apirig.utils.AuthTestsUtil;
 import io.mosip.testrig.apirig.utils.CertsUtil;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
+import io.mosip.testrig.apirig.utils.GlobalMethods;
 import io.mosip.testrig.apirig.utils.JWKKeyUtil;
 import io.mosip.testrig.apirig.utils.KernelAuthentication;
 import io.mosip.testrig.apirig.utils.KeyCloakUserAndAPIKeyGeneration;
@@ -77,6 +78,7 @@ public class MosipTestRunner {
 			IdRepoConfigManager.init();
 			suiteSetup(getRunType());
 			SkipTestCaseHandler.loadTestcaseToBeSkippedList("testCaseSkippedList.txt");
+			GlobalMethods.setModuleNameAndReCompilePattern(IdRepoConfigManager.getproperty("moduleNamePattern"));
 			setLogLevels();
 
 			// For now we are not doing health check for qa-115.

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoConfigManager.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoConfigManager.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
 import io.mosip.testrig.apirig.idrepo.testrunner.MosipTestRunner;
@@ -13,6 +14,9 @@ public class IdRepoConfigManager extends ConfigManager{
 	private static final Logger LOGGER = Logger.getLogger(IdRepoConfigManager.class);
 	
 	public static void init() {
+		Logger configManagerLogger = Logger.getLogger(ConfigManager.class);
+		configManagerLogger.setLevel(Level.WARN);
+		
 		Map<String, Object> moduleSpecificPropertiesMap = new HashMap<>();
 		// Load scope specific properties
 		try {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoUtil.java
@@ -1,5 +1,6 @@
 package io.mosip.testrig.apirig.idrepo.utils;
 
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.json.JSONArray;
 import org.testng.SkipException;
@@ -14,6 +15,13 @@ import io.mosip.testrig.apirig.utils.SkipTestCaseHandler;
 public class IdRepoUtil extends AdminTestUtil {
 
 	private static final Logger logger = Logger.getLogger(IdRepoUtil.class);
+	
+	public static void setLogLevel() {
+		if (IdRepoConfigManager.IsDebugEnabled())
+			logger.setLevel(Level.ALL);
+		else
+			logger.setLevel(Level.ERROR);
+	}
 	
 	public static String isTestCaseValidForExecution(TestCaseDTO testCaseDTO) {
 		String testCaseName = testCaseDTO.getTestCaseName();


### PR DESCRIPTION
The setLogLevel method was added to the commons classes to prevent sensitive information, like secrets, from being printed in the console logs.