### PR TITLE
Uncommented delete of entries from credential_request_status table

### DIFF
--- a/id-repository/id-repository-core/src/main/java/io/mosip/idrepository/core/manager/CredentialStatusManager.java
+++ b/id-repository/id-repository-core/src/main/java/io/mosip/idrepository/core/manager/CredentialStatusManager.java
@@ -140,7 +140,7 @@ public class CredentialStatusManager {
 						Objects.nonNull(credentialRequestStatus.getUpdDTimes()), null,
 						uinHashSaltRepo::retrieveSaltById, this::credentialRequestResponseConsumer,
 						this::idaEventConsumer, List.of(credentialRequestStatus.getPartnerId()),credentialRequestStatus.getRequestId());
-				deleteDummyPartner(credentialRequestStatus);
+				//deleteDummyPartner(credentialRequestStatus);
 			}
 		} catch (Exception e) {
 			mosipLogger.error(IdRepoSecurityManager.getUser(), this.getClass().getSimpleName(), "handleNewOrUpdatedRequests", ExceptionUtils.getStackTrace(e));


### PR DESCRIPTION
Entries are deleted immediately in credential_request_status hence the logic to identify the update request is failing