### PR TITLE
MOSIP-28246: Removed unused variables from idrepo module

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testrunner/MosipTestRunner.java
@@ -91,7 +91,7 @@ public class MosipTestRunner {
 			KeycloakUserManager.closeKeycloakInstance();
 			AdminTestUtil.getRequiredField();
 
-//			List<String> localLanguageList = new ArrayList<>(BaseTestCase.getLanguageList());
+			BaseTestCase.getLanguageList();
 			AdminTestUtil.getLocationData();
 			
 			// Generate device certificates to be consumed by Mock-MDS

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testrunner/MosipTestRunner.java
@@ -11,7 +11,7 @@ import java.security.PublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
+//import java.util.Map;
 import java.util.Properties;
 
 import org.apache.log4j.Level;
@@ -91,7 +91,7 @@ public class MosipTestRunner {
 			KeycloakUserManager.closeKeycloakInstance();
 			AdminTestUtil.getRequiredField();
 
-			List<String> localLanguageList = new ArrayList<>(BaseTestCase.getLanguageList());
+//			List<String> localLanguageList = new ArrayList<>(BaseTestCase.getLanguageList());
 			AdminTestUtil.getLocationData();
 			
 			// Generate device certificates to be consumed by Mock-MDS

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/SimplePostForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/SimplePostForAutoGenId.java
@@ -106,7 +106,7 @@ import io.restassured.response.Response;
 	
 			inputJson = getJsonFromTemplate(testCaseDTO.getInput(), testCaseDTO.getInputTemplate());
 	
-			String outputJson = getJsonFromTemplate(testCaseDTO.getOutput(), testCaseDTO.getOutputTemplate());
+//			String outputJson = getJsonFromTemplate(testCaseDTO.getOutput(), testCaseDTO.getOutputTemplate());
 	
 			if (testCaseDTO.getTemplateFields() != null && templateFields.length > 0) {
 				ArrayList<JSONObject> inputtestCases = AdminTestUtil.getInputTestCase(testCaseDTO);

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/UpdateIdentity.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/UpdateIdentity.java
@@ -31,7 +31,7 @@ import io.mosip.testrig.apirig.idrepo.utils.IdRepoUtil;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.utils.AdminTestException;
-import io.mosip.testrig.apirig.utils.AdminTestUtil;
+//import io.mosip.testrig.apirig.utils.AdminTestUtil;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
@@ -145,7 +145,7 @@ public class UpdateIdentity extends IdRepoUtil implements ITest {
 
 		String inputJson = getJsonFromTemplate(testCaseDTO.getInput(), testCaseDTO.getInputTemplate());
 
-		JSONObject reqJsonObject = new JSONObject(inputJson);
+//		JSONObject reqJsonObject = new JSONObject(inputJson);
 
 		
 

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/UpdateIdentityForArrayHandles.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/UpdateIdentityForArrayHandles.java
@@ -36,7 +36,7 @@ import io.mosip.testrig.apirig.utils.AdminTestUtil;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
-import io.mosip.testrig.apirig.utils.PartnerRegistration;
+//import io.mosip.testrig.apirig.utils.PartnerRegistration;
 import io.mosip.testrig.apirig.utils.ReportUtil;
 import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoArrayHandle.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoArrayHandle.java
@@ -164,7 +164,7 @@ public class IdRepoArrayHandle {
 	                    if (identity.has("selectedHandles")) {
 
 	                        if (selectedHandles.length() > 0) {
-	                            String firstHandleToKeep = selectedHandles.getString(0);
+//	                            String firstHandleToKeep = selectedHandles.getString(0);
 
 	                            for (int j = 1; j < selectedHandles.length(); j++) {
 	                                if (identity.has(handle)) {
@@ -182,7 +182,7 @@ public class IdRepoArrayHandle {
 	                    if (identity.has("selectedHandles")) {
 
 	                        if (selectedHandles.length() > 0) {
-	                            String firstHandleToKeep = selectedHandles.getString(0);
+//	                            String firstHandleToKeep = selectedHandles.getString(0);
 
 	                            for (int j = 1; j < selectedHandles.length(); j++) {
 	                                if (identity.has(handle)) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoUtil.java
@@ -38,7 +38,7 @@ public class IdRepoUtil extends AdminTestUtil {
 		String dob = dobArray.getString(0);
 		JSONArray emailArray = new JSONArray(getValueFromAuthActuator("json-property", "emailId"));
 		String email = emailArray.getString(0);
-		JSONArray phoneArray = new JSONArray(getValueFromAuthActuator("json-property", "phone_number"));
+//		JSONArray phoneArray = new JSONArray(getValueFromAuthActuator("json-property", "phone_number"));
 
 		if (testCaseName.startsWith("IdRepository_") && testCaseName.contains("DOB")
 				&& (!isElementPresent(globalRequiredFields, dob))) {


### PR DESCRIPTION
Commented out unused variables in the idrepo module to improve code cleanliness and maintainability. Identified via static code analysis. No functional changes made.