### PR TITLE
MOSIP-37218: API - Cross check IDREPO Related error code

### DIFF
--- a/api-test/src/main/resources/idRepository/RetrieveIdentityByRid/RetrieveIdentityByRid.yml
+++ b/api-test/src/main/resources/idRepository/RetrieveIdentityByRid/RetrieveIdentityByRid.yml
@@ -38,17 +38,14 @@ RetrieveIdentityByRid:
       uniqueIdentifier: TC_IDRepo_RetrieveIdentityByRID_03
       role: idrepo
       restMethod: get
+      checkOnlyStatusCodeInResponse: true
       inputTemplate: idRepository/RetrieveIdentityByRid/retrieveIdentityByRid
-      outputTemplate: idRepository/error
+      outputTemplate: idRepository/responseCode
       input: '{
       "RID":""
       }'
       output: '{
-        "errors": [
-          {
-            "errorCode": "IDR-IDC-003"
-          }
-        ]
+        "responseCode": "500"
       }'
 
   IdRepository_RetrieveIdentityByRid_SpaceVal_Rid_Neg:

--- a/api-test/src/main/resources/idRepository/RetrieveIdentityByUin/RetrieveIdentityByUin.yml
+++ b/api-test/src/main/resources/idRepository/RetrieveIdentityByUin/RetrieveIdentityByUin.yml
@@ -87,17 +87,14 @@ RetrieveIdentity:
       uniqueIdentifier: TC_IDRepo_RetrieveIdentityByUIN_06
       role: idrepo
       restMethod: get
+      checkOnlyStatusCodeInResponse: true
       inputTemplate: idRepository/RetrieveIdentityByUin/retrieveIdentityByUin
-      outputTemplate: idRepository/error
+      outputTemplate: idRepository/responseCode
       input: '{
     "id": ""
 }'
       output: '{
-   "errors": [
-    {
-      "errorCode": "IDR-IDC-003"
-    }
-  ]
+        "responseCode": "500"
 }'
 
   IdRepository_RetrieveIdentity_With_Invalid_Vid:
@@ -124,17 +121,14 @@ RetrieveIdentity:
       uniqueIdentifier: TC_IDRepo_RetrieveIdentityByUIN_08
       role: idrepo
       restMethod: get
+      checkOnlyStatusCodeInResponse: true
       inputTemplate: idRepository/RetrieveIdentityByUin/retrieveIdentityByUin
-      outputTemplate: idRepository/error
+      outputTemplate: idRepository/responseCode
       input: '{
     "id": ""
 }'
       output: '{
-   "errors": [
-    {
-      "errorCode": "IDR-IDC-003"
-    }
-  ]
+        "responseCode": "500"
 }'
 
   IdRepository_RetrieveIdentity_With_SpaceVal_UIN:

--- a/api-test/src/main/resources/idRepository/RetrieveVIDByUIN/RetrieveVIDByUIN.yml
+++ b/api-test/src/main/resources/idRepository/RetrieveVIDByUIN/RetrieveVIDByUIN.yml
@@ -91,17 +91,14 @@ RetrieveVIDByUIN:
       uniqueIdentifier: TC_IDRepo_RetrieveVIDByUIN_06
       role: idrepo
       restMethod: get
+      checkOnlyStatusCodeInResponse: true
       inputTemplate: idRepository/RetrieveVIDByUIN/retrieveVIDByUIN
-      outputTemplate: idRepository/error
+      outputTemplate: idRepository/responseCode
       input: '{
       "UIN":""
       }'
       output: '{
-   "errors": [
-    {
-      "errorCode": "IDR-IDC-003"
-    }
-  ]
+        "responseCode": "500"
 }'
 
   IdRepository_RetrieveVIDByUIN_With_Space Uin:


### PR DESCRIPTION
Changed negative IDRepo tests to validate only response status code (500) for empty or blank inputs by enabling checkOnlyStatusCodeInResponse.