### PR TITLE
 MOSIP-42913: Invalid Expectation in IDRepo API Test Rig

### DIFF
--- a/api-test/src/main/resources/idRepository/GetUpdateCount/GetUpdateCount.yml
+++ b/api-test/src/main/resources/idRepository/GetUpdateCount/GetUpdateCount.yml
@@ -93,7 +93,7 @@ GetUpdateCount:
       "idType": "UIN",
        "attribute_list": "fullName"
 }'
-      output: "500"
+      output: "401"
 
    IdRepository_GetUpdateCount_Vid_Valid_Smoke:
       endPoint: /idrepository/v1/identity/{individualId}/update-counts?idType={idType}&attribute_list={attribute_list}
@@ -189,7 +189,7 @@ GetUpdateCount:
       "idType": "VID",
        "attribute_list": "fullName"
 }'
-      output: "500"
+      output: "401"
       
    IdRepository_GetUpdateCount_Uin_Invalid_idType:
       endPoint: /idrepository/v1/identity/{individualId}/update-counts?idType={idType}&attribute_list={attribute_list}


### PR DESCRIPTION
Updated the expected status code in YAML test definitions from 500 to 401 for invalid token scenarios (**IdRepository_GetUpdateCount_Uin_StatusCode_Invalid_Token** and **IdRepository_GetUpdateCount_Uinn_StatusCode_Invalid_Token**).