### PR TITLE
MOSIP-42913: Invalid Expectation in IDRepo API Test Rig, Fixed the nexus failure.

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -43,6 +43,15 @@
 				<enabled>true</enabled>
 			</snapshots>
 		</repository>
+		<repository>
+			<id>central</id>
+			<name>MavenCentral</name>
+			<layout>default</layout>
+			<url>https://repo1.maven.org/maven2</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
 	</repositories>
 
 	<properties>


### PR DESCRIPTION
Added MavenCentral repository for fixing the nexus failure.