### PR TITLE
MOSIP-33663: Added Negative testcases for AddIdentity and CreateVID.

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.4.0-SNAPSHOT</version>
+			<version>1.5.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 	<distributionManagement>

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/AddIdentity.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/AddIdentity.java
@@ -37,6 +37,7 @@ import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.testrunner.JsonPrecondtion;
 import io.mosip.testrig.apirig.utils.AdminTestException;
 import io.mosip.testrig.apirig.utils.AdminTestUtil;
+import io.mosip.testrig.apirig.id.IdGenerator;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.KernelAuthentication;
@@ -99,12 +100,21 @@ public class AddIdentity extends IdRepoUtil implements ITest {
 					GlobalConstants.TARGET_ENV_HEALTH_CHECK_FAILED + HealthChecker.healthCheckFailureMapS);
 		}
 		testCaseDTO.setInputTemplate(AdminTestUtil.modifySchemaGenerateHbs(testCaseDTO.isRegenerateHbs()));
-		String uin = JsonPrecondtion
-				.getValueFromJson(
-						RestClient.getRequestWithCookie(ApplnURI + "/v1/idgenerator/uin", MediaType.APPLICATION_JSON,
-								MediaType.APPLICATION_JSON, COOKIENAME,
-								new KernelAuthentication().getTokenByRole(testCaseDTO.getRole())).asString(),
-						"response.uin");
+		String jsonInput = testCaseDTO.getInput();
+
+		String inputJson = getJsonFromTemplate(jsonInput, testCaseDTO.getInputTemplate(), false);
+		String uin;
+		if(inputJson.contains("$INVALID_UIN$")) {
+			uin = IdGenerator.generateInvalidUin();
+		} else if (inputJson.contains("$VALID_UIN_NOTIN_DB$")) {
+			uin = IdGenerator.generateValidUin();
+		} else {
+			uin = JsonPrecondtion.getValueFromJson(
+					RestClient.getRequestWithCookie(ApplnURI + "/v1/idgenerator/uin", MediaType.APPLICATION_JSON,
+							MediaType.APPLICATION_JSON, COOKIENAME,
+							new KernelAuthentication().getTokenByRole(testCaseDTO.getRole())).asString(),
+					"response.uin");
+		}
 
 		DateFormat dateFormatter = new SimpleDateFormat("yyyyMMddHHmmss");
 		Calendar cal = Calendar.getInstance();
@@ -131,10 +141,7 @@ public class AddIdentity extends IdRepoUtil implements ITest {
 					attrmap);
 		}
 
-		String jsonInput = testCaseDTO.getInput();
 
-		String inputJson = getJsonFromTemplate(jsonInput, testCaseDTO.getInputTemplate(), false);
-		
 		
 		//For_Array-Handle Related Cases
 		if (inputJson.contains("$FUNCTIONALID$")) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/AddIdentity.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/AddIdentity.java
@@ -37,7 +37,6 @@ import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.testrunner.JsonPrecondtion;
 import io.mosip.testrig.apirig.utils.AdminTestException;
 import io.mosip.testrig.apirig.utils.AdminTestUtil;
-import io.mosip.testrig.apirig.id.IdGenerator;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.KernelAuthentication;
@@ -103,12 +102,8 @@ public class AddIdentity extends IdRepoUtil implements ITest {
 		String jsonInput = testCaseDTO.getInput();
 
 		String inputJson = getJsonFromTemplate(jsonInput, testCaseDTO.getInputTemplate(), false);
-		String uin;
-		if(inputJson.contains("$INVALID_UIN$")) {
-			uin = IdGenerator.generateInvalidUin();
-		} else if (inputJson.contains("$VALID_UIN_NOTIN_DB$")) {
-			uin = IdGenerator.generateValidUin();
-		} else {
+		String uin = null;
+		if (inputJson.contains("$UIN$")) {
 			uin = JsonPrecondtion.getValueFromJson(
 					RestClient.getRequestWithCookie(ApplnURI + "/v1/idgenerator/uin", MediaType.APPLICATION_JSON,
 							MediaType.APPLICATION_JSON, COOKIENAME,
@@ -126,6 +121,9 @@ public class AddIdentity extends IdRepoUtil implements ITest {
 			KeycloakUserManager.removeVidUser();
 			Map<String, List<String>> attrmap = new HashMap<>();
 			List<String> list = new ArrayList<>();
+			if (uin == null) {
+		        throw new IllegalStateException("UIN not initialized");
+		    }
 			list.add(uin);
 			attrmap.put("individual_id", list);
 			list = new ArrayList<>();
@@ -163,7 +161,9 @@ public class AddIdentity extends IdRepoUtil implements ITest {
 			inputJson = replaceKeywordWithValue(inputJson, "$EMAILVALUE$", "  ");
 		}
 
-		inputJson = inputJson.replace("$UIN$", uin);
+		if (uin != null) {
+			inputJson = inputJson.replace("$UIN$", uin);
+		}
 		inputJson = inputJson.replace("$RID$", genRid);
 		String phoneNumber = "";
 		String email = testCaseName + "_" + BaseTestCase.runContext + "@mosip.net";

--- a/api-test/src/main/resources/idRepository/AddIdentity/AddIdentity.yml
+++ b/api-test/src/main/resources/idRepository/AddIdentity/AddIdentity.yml
@@ -1511,3 +1511,77 @@ AddIdentity:
       output: '{
   "status":"ACTIVATED"
 }'
+   IdRepository_AddIdentity_with_InvalidUIN:
+      endPoint: /idrepository/v1/identity/
+      description: Creating UIN in Add Identity with invalid UIN parameters
+      uniqueIdentifier: TC_IDRepo_AddIdentity_41
+      role: testrig
+      restMethod: post
+      inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
+      outputTemplate: idRepository/error
+      input: '{
+  "value": "$BIOVALUE$",
+  "id": "mosip.id.create",
+  "registrationId": "$RID$",
+  "addressCopy": "Y",
+  "biometricReferenceId": "23452353",
+ 
+   "UIN": "$INVALID_UIN$",
+   
+  "dateOfBirth": "1992/04/15",
+   
+  "postalCode": "14022",
+  "email": "mosipuser123@mailinator.com",
+  "phone": "8249742850",
+  "mobileno": "8249742850",
+  "referenceIdentityNumber": "6789545678878",
+  "version": "v1",
+ 
+   "introducerRID": "212124324784879",
+   "introducerUIN": "212124324784879",
+   
+   "category": "individualBiometrics",
+   "requesttime": "$TIMESTAMP$"
+}'
+      output: '{
+   "errors": [
+     {
+        "errorCode": "IDR-IDC-002"
+     }
+   ]
+}'
+   IdRepository_AddIdentity_with_ValidUIN_NotIn_DB_Neg:
+      endPoint: /idrepository/v1/identity/
+      description: Creating UIN in Add Identity with valid UIN not present in DB
+      uniqueIdentifier: TC_IDRepo_AddIdentity_42
+      role: testrig
+      restMethod: post
+      inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
+      outputTemplate: idRepository/AddIdentity/addIdentityResult
+      input: '{
+  "value": "$BIOVALUE$",
+  "id": "mosip.id.create",
+  "registrationId": "$RID$",
+  "addressCopy": "Y",
+  "biometricReferenceId": "23452353",
+ 
+   "UIN": "$VALID_UIN_NOTIN_DB$",
+   
+  "dateOfBirth": "1992/04/15",
+   
+  "postalCode": "14022",
+  "email": "mosipuser123@mailinator.com",
+  "phone": "8249742850",
+  "mobileno": "8249742850",
+  "referenceIdentityNumber": "6789545678878",
+  "version": "v1",
+ 
+   "introducerRID": "212124324784879",
+   "introducerUIN": "212124324784879",
+   
+   "category": "individualBiometrics",
+   "requesttime": "$TIMESTAMP$"
+}'
+      output: '{
+   "status":"ACTIVATED"
+}'

--- a/api-test/src/main/resources/idRepository/AddIdentity/AddIdentity.yml
+++ b/api-test/src/main/resources/idRepository/AddIdentity/AddIdentity.yml
@@ -1550,7 +1550,7 @@ AddIdentity:
      }
    ]
 }'
-   IdRepository_AddIdentity_with_ValidUIN_NotIn_DB_Neg:
+   IdRepository_AddIdentity_with_ValidUIN_NotIn_DB:
       endPoint: /idrepository/v1/identity/
       description: Creating UIN in Add Identity with valid UIN not present in DB
       uniqueIdentifier: TC_IDRepo_AddIdentity_42

--- a/api-test/src/main/resources/idRepository/AddIdentity/AddIdentity.yml
+++ b/api-test/src/main/resources/idRepository/AddIdentity/AddIdentity.yml
@@ -1511,7 +1511,7 @@ AddIdentity:
       output: '{
   "status":"ACTIVATED"
 }'
-   IdRepository_AddIdentity_with_InvalidUIN:
+   IdRepository_AddIdentity_with_InvalidUIN_Neg:
       endPoint: /idrepository/v1/identity/
       description: Creating UIN in Add Identity with invalid UIN parameters
       uniqueIdentifier: TC_IDRepo_AddIdentity_41

--- a/api-test/src/main/resources/idRepository/CreateVID/CreateVid.yml
+++ b/api-test/src/main/resources/idRepository/CreateVID/CreateVid.yml
@@ -975,3 +975,49 @@ CreateVID:
       output: '{
   "vidStatus":"ACTIVE"
 }'
+
+  IdRepository_CreateVID_With_InvalidUIN_Neg:
+      endPoint: /idrepository/v1/vid
+      description: Create a Temporary VID passing Invalid UIN
+      uniqueIdentifier: TC_IDRepo_CreateVID_48
+      role: idrepo
+      restMethod: post
+      inputTemplate: idRepository/CreateVID/createVid
+      outputTemplate: idRepository/error
+      input: '{
+    "vidType": "Temporary",
+    "UIN": "$INVALID_UIN$",
+    "version": "v1",
+    "id": "mosip.vid.create",
+    "requesttime": "$TIMESTAMP$"
+}'
+      output: '{
+    "errors": [
+       {
+          "errorCode": "IDR-IDC-002"
+       }
+     ]
+}'
+
+  IdRepository_CreateVID_With_ValidUIN_But_Not_In_DB_Neg:
+      endPoint: /idrepository/v1/vid
+      description: Create a Temporary VID passing valid UIN but not present in DB
+      uniqueIdentifier: TC_IDRepo_CreateVID_49
+      role: idrepo
+      restMethod: post
+      inputTemplate: idRepository/CreateVID/createVid
+      outputTemplate: idRepository/error
+      input: '{
+    "vidType": "Temporary",
+    "UIN": "$VALID_UIN_NOTIN_DB$",
+    "version": "v1",
+    "id": "mosip.vid.create",
+    "requesttime": "$TIMESTAMP$"
+}'
+      output: '{
+    "errors": [
+      {
+         "errorCode": "IDR-IDC-007"
+      }
+    ]
+}'


### PR DESCRIPTION
Added Negative testcases for Invalid UIN and Valid UIN not present in db in AddIdentity and CreateVID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests for AddIdentity covering invalid UIN and valid-but-not-in-database UIN, verifying error and activation flows.
  * Added tests for CreateVID covering invalid UIN and valid-but-not-in-database UIN, validating specific error responses.
  * Expanded negative/error handling coverage with explicit error-code validations.

* **Chores**
  * Bumped apitest-commons dependency version in build configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->