### PR TITLE
MOSIP- 44419: Removed reflection-based TestNG method name modification.

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.4.0-SNAPSHOT</version>
+			<version>1.5.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 	<distributionManagement>

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/AddIdentity.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/AddIdentity.java
@@ -199,17 +199,7 @@ public class AddIdentity extends IdRepoUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 
 	@AfterClass(alwaysRun = true)

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/DeleteWithParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/DeleteWithParam.java
@@ -135,16 +135,6 @@ public class DeleteWithParam extends IdRepoUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/GetWithParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/GetWithParam.java
@@ -162,16 +162,6 @@ public class GetWithParam extends IdRepoUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/GetWithParamForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/GetWithParamForAutoGenId.java
@@ -149,16 +149,6 @@ public class GetWithParamForAutoGenId extends IdRepoUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/PatchWithPathParamsAndBody.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/PatchWithPathParamsAndBody.java
@@ -129,16 +129,6 @@ public class PatchWithPathParamsAndBody extends IdRepoUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/PostWithOnlyPathParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/PostWithOnlyPathParam.java
@@ -151,16 +151,6 @@ public class PostWithOnlyPathParam extends IdRepoUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/PutWithPathParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/PutWithPathParam.java
@@ -137,16 +137,6 @@ public class PutWithPathParam extends IdRepoUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/SimplePost.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/SimplePost.java
@@ -164,16 +164,6 @@ public class SimplePost extends IdRepoUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/SimplePostForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/SimplePostForAutoGenId.java
@@ -158,16 +158,6 @@ import io.restassured.response.Response;
 		 */
 		@AfterMethod(alwaysRun = true)
 		public void setResultTestName(ITestResult result) {
-			try {
-				Field method = TestResult.class.getDeclaredField("m_method");
-				method.setAccessible(true);
-				method.set(result, result.getMethod().clone());
-				BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-				Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-				f.setAccessible(true);
-				f.set(baseTestMethod, testCaseName);
-			} catch (Exception e) {
-				Reporter.log("Exception : " + e.getMessage());
-			}
+			result.setAttribute("TestCaseName", testCaseName);
 		}
 	}

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/UpdateDraft.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/UpdateDraft.java
@@ -116,17 +116,7 @@ public class UpdateDraft extends IdRepoUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 
 	@AfterClass(alwaysRun = true)

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/UpdateIdentity.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/UpdateIdentity.java
@@ -218,16 +218,6 @@ public class UpdateIdentity extends IdRepoUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/UpdateIdentityForArrayHandles.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/UpdateIdentityForArrayHandles.java
@@ -181,16 +181,6 @@ public class UpdateIdentityForArrayHandles extends IdRepoUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }


### PR DESCRIPTION
MOSIP- 44419: Removed reflection-based TestNG method name modification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified test result handling across multiple test scripts by replacing reflective field manipulation with direct attribute assignment.

* **Chores**
  * Updated apitest-commons dependency to version 1.5.0-SNAPSHOT.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->