### PR TITLE
MOSIP-44198: Resolve OOM errors under high load in identity service — biometric memory and cache fixes    

### DIFF
--- a/id-repository/id-repository-identity-service/src/main/java/io/mosip/idrepository/identity/helper/AnonymousProfileHelper.java
+++ b/id-repository/id-repository-identity-service/src/main/java/io/mosip/idrepository/identity/helper/AnonymousProfileHelper.java
@@ -124,6 +124,12 @@ public class AnonymousProfileHelper {
 		} catch (Exception e) {
 			mosipLogger.warn(IdRepoSecurityManager.getUser(), "AnonymousProfileHelper", "buildAndsaveProfile",
 					ExceptionUtils.getStackTrace(e));
+		} finally {
+			// Release only the large byte arrays after async processing completes.
+			// oldCbeff/newCbeff are retained so callers can still query isOldCbeffPresent/isNewCbeffPresent.
+			// resetData() (full reset) is triggered by setRegId() on the next request.
+			this.oldUinData = null;
+			this.newUinData = null;
 		}
 	}
 

--- a/id-repository/id-repository-identity-service/src/main/java/io/mosip/idrepository/identity/helper/IdRepoServiceHelper.java
+++ b/id-repository/id-repository-identity-service/src/main/java/io/mosip/idrepository/identity/helper/IdRepoServiceHelper.java
@@ -55,9 +55,22 @@ public class IdRepoServiceHelper {
 
     private static final String REQUEST = "request";
 
-    /** The schema map. */
-    private static Map<String, String> schemaMap = new HashMap<>();
-    private static Map<String, List<String>> supportedHandlesInSchema = new HashMap<>();
+    /** The schema map. Max size prevents unbounded heap growth from many schema versions. */
+    private static final int MAX_SCHEMA_CACHE_SIZE = 100;
+    private static final Map<String, String> schemaMap = Collections.synchronizedMap(
+            new LinkedHashMap<String, String>(16, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, String> eldest) {
+                    return size() > MAX_SCHEMA_CACHE_SIZE;
+                }
+            });
+    private static final Map<String, List<String>> supportedHandlesInSchema = Collections.synchronizedMap(
+            new LinkedHashMap<String, List<String>>(16, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, List<String>> eldest) {
+                    return size() > MAX_SCHEMA_CACHE_SIZE;
+                }
+            });
 
     @Autowired
     private ObjectMapper mapper;
@@ -136,9 +149,10 @@ public class IdRepoServiceHelper {
                 restRequest = restBuilder.buildRequest(RestServicesConstants.SYNCDATA_SERVICE, null, ResponseWrapper.class);
                 restRequest.setUri(restRequest.getUri().concat("?schemaVersion=" + schemaVersion));
                 ResponseWrapper<Map<String, String>> response = restHelper.requestSync(restRequest);
-                schemaMap.put(schemaVersion, response.getResponse().get("schemaJson"));
-                supportedHandlesInSchema.put(schemaVersion, getSupportedHandles(response.getResponse().get("schemaJson")));
-                return getSchema(schemaVersion);
+                String schema = response.getResponse().get("schemaJson");
+                schemaMap.put(schemaVersion, schema);
+                supportedHandlesInSchema.put(schemaVersion, getSupportedHandles(schema));
+                return schema; // return directly - no recursive call needed
             }
         } catch (IdRepoDataValidationException | RestServiceException e) {
             mosipLogger.error(IdRepoSecurityManager.getUser(), ID_REPO_SERVICE_HELPER, "getSchema", "\n" + e.getMessage());

--- a/id-repository/id-repository-identity-service/src/main/java/io/mosip/idrepository/identity/helper/ObjectStoreHelper.java
+++ b/id-repository/id-repository-identity-service/src/main/java/io/mosip/idrepository/identity/helper/ObjectStoreHelper.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BoundedInputStream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
@@ -42,6 +43,9 @@ public class ObjectStoreHelper {
 
 	@Value("${" + OBJECT_STORE_ADAPTER_NAME + "}")
 	private String objectStoreAdapterName;
+
+	@Value("${mosip.idrepo.objectstore.max-object-size-bytes:10485760}")
+	private long maxObjectSizeBytes = 10 * 1024 * 1024L; // 10 MB; also configurable via property
 
 	private ObjectStoreAdapter objectStore;
 
@@ -123,8 +127,17 @@ public class ObjectStoreHelper {
 		if (rawStream == null) {
 			throw new IdRepoAppException(FILE_NOT_FOUND);
 		}
-		try (InputStream s3Stream = new BufferedInputStream(rawStream)) {
-			return securityManager.decrypt(IOUtils.toByteArray(s3Stream), refId);
+		// BoundedInputStream limits read to maxObjectSizeBytes+1 so we can detect oversized objects
+		// without reading the entire stream, preventing unbounded heap allocation.
+		try (InputStream s3Stream = new BoundedInputStream(new BufferedInputStream(rawStream), maxObjectSizeBytes + 1)) {
+			byte[] encryptedData = IOUtils.toByteArray(s3Stream);
+			if (encryptedData.length > maxObjectSizeBytes) {
+				throw new IdRepoAppException(FILE_STORAGE_ACCESS_ERROR.getErrorCode(),
+						"Object size exceeds allowed limit (" + maxObjectSizeBytes + " bytes): " + objectName);
+			}
+			byte[] decryptedData = securityManager.decrypt(encryptedData, refId);
+			encryptedData = null; // release encrypted copy; decryptedData is the only live reference now
+			return decryptedData;
 		} catch (IOException | ObjectStoreAdapterException e) {
 			throw new IdRepoAppException(FILE_STORAGE_ACCESS_ERROR.getErrorCode(),
 					"Failed to retrieve object: " + e.getMessage(), e);

--- a/id-repository/id-repository-identity-service/src/main/java/io/mosip/idrepository/identity/service/impl/BiometricExtractionServiceImpl.java
+++ b/id-repository/id-repository-identity-service/src/main/java/io/mosip/idrepository/identity/service/impl/BiometricExtractionServiceImpl.java
@@ -78,6 +78,7 @@ public class BiometricExtractionServiceImpl implements BiometricExtractionServic
 							"RETURNING EXISTING EXTRACTED BIOMETRICS FOR FORMAT: " + extractionType +" : "+ extractionFormat);
 					byte[] xmlBytes = objectStoreHelper.getBiometricObject(uinHash, extractionFileName);
 					List<BIR> existingBirs = cbeffUtil.getBIRDataFromXML(xmlBytes);
+					xmlBytes = null; // release large byte array before returning; BIR objects are much smaller
 					return CompletableFuture.completedFuture(existingBirs);
 				}
 			} catch (ObjectStoreAdapterException e) {

--- a/id-repository/id-repository-identity-service/src/main/java/io/mosip/idrepository/identity/service/impl/IdRepoProxyServiceImpl.java
+++ b/id-repository/id-repository-identity-service/src/main/java/io/mosip/idrepository/identity/service/impl/IdRepoProxyServiceImpl.java
@@ -443,6 +443,7 @@ public class IdRepoProxyServiceImpl implements IdRepoService<IdRequestDTO, IdRes
 				}
 			}
 
+			originalBirs.clear(); // release parsed BIR list before blocking on futures - reduces live set during wait
 			CompletableFuture.allOf(extractionFutures.toArray(new CompletableFuture<?>[extractionFutures.size()]))
 					.join();
 			for (CompletableFuture<List<BIR>> future : extractionFutures) {

--- a/id-repository/id-repository-identity-service/src/main/java/io/mosip/idrepository/identity/service/impl/IdRepoServiceImpl.java
+++ b/id-repository/id-repository-identity-service/src/main/java/io/mosip/idrepository/identity/service/impl/IdRepoServiceImpl.java
@@ -438,7 +438,7 @@ public class IdRepoServiceImpl implements IdRepoService<IdRequestDTO, Uin> {
 						.mappingProvider(new JacksonMappingProvider()).build();
 				DocumentContext inputData = JsonPath.using(configuration).parse(requestDTO.getIdentity());
 				DocumentContext dbData = JsonPath.using(configuration).parse(new String(uinObject.getUinData()));
-				anonymousProfileHelper.setOldUinData(dbData.jsonString().getBytes());
+				anonymousProfileHelper.setOldUinData(uinObject.getUinData()); // reuse existing bytes - no copy needed
 				updateVerifiedAttributes(requestDTO, inputData, dbData);
 				replaceConfiguredFieldsOnUpdate(inputData, dbData);
 				JSONCompareResult comparisonResult = JSONCompare.compareJSON(inputData.jsonString(),
@@ -447,7 +447,7 @@ public class IdRepoServiceImpl implements IdRepoService<IdRequestDTO, Uin> {
 				if (comparisonResult.failed()) {
 					updateJsonObject(uinHash, inputData, dbData, comparisonResult, true);
 				}
-				uinObject.setUinData(convertToBytes(convertToObject(dbData.jsonString().getBytes(), Map.class)));
+				uinObject.setUinData(convertToBytes(dbData.json())); // eliminates intermediate String->bytes->Map->bytes conversions
 				uinObject.setUinDataHash(securityManager.hash(uinObject.getUinData()));
 				uinObject.setUpdatedBy(IdRepoSecurityManager.getUser());
 				uinObject.setUpdatedDateTime(DateUtils2.getUTCCurrentDateTime());
@@ -576,8 +576,10 @@ public class IdRepoServiceImpl implements IdRepoService<IdRequestDTO, Uin> {
 		}
 		comparisonResult = JSONCompare.compareJSON(inputData.jsonString(), dbData.jsonString(), JSONCompareMode.LENIENT);
 		if (comparisonResult.failed()) {
-			// Code should never reach here
-			updateJsonObject(uinHash, inputData, dbData, comparisonResult, true);
+			// Should never reach here - log and bail instead of recursing to prevent unbounded stack growth
+			mosipLogger.warn(IdRepoSecurityManager.getUser(), ID_REPO_SERVICE_IMPL, "updateJsonObject",
+					"Comparison still failing after all update passes for uinHash: " + uinHash
+							+ " - remaining diff: " + comparisonResult.getMessage());
 		}
 		identityUpdateTracker.save(new IdentityUpdateTracker(updateCountTracker.getKey(), CryptoUtil
 				.encodeToURLSafeBase64(mapper.writeValueAsString(updateCountTrackerMap).getBytes()).getBytes()));


### PR DESCRIPTION
1. Reduced heap pressure during biometric and identity processing
2. Eliminated unbounded cache growth
3. Prevented potential stack overflows from unbounded recursion
4. Added hard limit on object store reads to guard against oversized payloads