### PR TITLE
MOSIP-44709: Fixed HealthCheck module mapping by using normalized module name instead of prefixed identifier.

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testrunner/MosipTestRunner.java
@@ -83,7 +83,7 @@ public class MosipTestRunner {
 			setLogLevels();
 
 			HealthChecker healthcheck = new HealthChecker();
-			healthcheck.setCurrentRunningModule(BaseTestCase.currentModule);
+			healthcheck.setCurrentRunningModule(GlobalConstants.IDREPO);
 			Thread trigger = new Thread(healthcheck);
 			trigger.start();
 			


### PR DESCRIPTION
Fixes HealthCheck module mismatch by replacing the prefixed module name (BaseTestCase.currentModule) with a normalized value (GlobalConstants.IDREPO), ensuring correct mapping with healthCheckEndpoint.properties and proper endpoint filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed health checker initialization in test execution to use correct module context configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->