### PR TITLE
MOSIP-44847: Fixed the logger issue

### DIFF
--- a/id-repository/credential-request-generator/src/main/java/io/mosip/credential/request/generator/CredentialRequestGeneratorBootApplication.java
+++ b/id-repository/credential-request-generator/src/main/java/io/mosip/credential/request/generator/CredentialRequestGeneratorBootApplication.java
@@ -20,7 +20,7 @@ import io.mosip.kernel.dataaccess.hibernate.config.HibernateDaoConfig;
  *
  */
 @SpringBootApplication
-@Import(value = { java.lang.String.class, DummyPartnerCheckUtil.class, RestHelper.class, IdRepoSecurityManager.class,
+@Import(value = { java.lang.String.class, DummyPartnerCheckUtil.class, IdRepoSecurityManager.class,
 		CredentialRequestGeneratorConfig.class})
 @ComponentScan(basePackages = { "io.mosip.credential.*","io.mosip.idrepository.*", "io.mosip.kernel.*", "${mosip.auth.adapter.impl.basepackage}" }, excludeFilters = {
 		@ComponentScan.Filter(type = FilterType.ASPECTJ, pattern = { "io.mosip.kernel.dataaccess.hibernate.config.*" }),

--- a/id-repository/credential-request-generator/src/main/java/io/mosip/credential/request/generator/api/config/CredentialRequestGeneratorConfig.java
+++ b/id-repository/credential-request-generator/src/main/java/io/mosip/credential/request/generator/api/config/CredentialRequestGeneratorConfig.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.mosip.idrepository.core.helper.RestHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springdoc.core.models.GroupedOpenApi;
@@ -29,6 +30,7 @@ import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 @EnableJpaRepositories(entityManagerFactoryRef = "entityManagerFactory", basePackages = "io.mosip.credential.request.generator.repositary.*", repositoryBaseClass = HibernateRepositoryImpl.class, excludeFilters = {
@@ -87,6 +89,10 @@ public class CredentialRequestGeneratorConfig extends HibernateDaoConfig {
 				.map(RestServicesConstants::getServiceName).collect(Collectors.toList()));
 	}
 
+	@Bean
+	public RestHelper restHelper(@Qualifier("selfTokenWebClient") WebClient webClient) {
+		return new RestHelper(webClient);
+	}
 
 	/**
 	 * Default async executor for @Async methods (e.g. RestHelper.requestAsync).

--- a/id-repository/credential-service/src/main/java/io/mosip/credentialstore/config/CredentialStoreBeanConfig.java
+++ b/id-repository/credential-service/src/main/java/io/mosip/credentialstore/config/CredentialStoreBeanConfig.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.caffeine.CaffeineCache;
@@ -28,6 +29,7 @@ import io.mosip.idrepository.core.helper.AuditHelper;
 import io.mosip.idrepository.core.helper.RestHelper;
 import io.mosip.idrepository.core.security.IdRepoSecurityManager;
 import io.mosip.idrepository.core.util.DummyPartnerCheckUtil;
+import org.springframework.web.reactive.function.client.WebClient;
 
 /**
  * The Class CredentialStoreConfig.
@@ -125,11 +127,9 @@ public class CredentialStoreBeanConfig {
 	}
 
 	@Bean
-	public RestHelper restHelper() {
-		return new RestHelper();
+	public RestHelper restHelper(@Qualifier("selfTokenWebClient") WebClient webClient) {
+		return new RestHelper(webClient);
 	}
-
-
 
 	@Bean
 	public AfterburnerModule afterburnerModule() {

--- a/id-repository/id-repository-core/src/main/java/io/mosip/idrepository/core/helper/RestHelper.java
+++ b/id-repository/id-repository-core/src/main/java/io/mosip/idrepository/core/helper/RestHelper.java
@@ -1,10 +1,5 @@
 package io.mosip.idrepository.core.helper;
 
-import static io.mosip.idrepository.core.constant.IdRepoErrorConstants.CLIENT_ERROR;
-import static io.mosip.idrepository.core.constant.IdRepoErrorConstants.CONNECTION_TIMED_OUT;
-import static io.mosip.idrepository.core.constant.IdRepoErrorConstants.SERVER_ERROR;
-import static io.mosip.idrepository.core.constant.IdRepoErrorConstants.UNKNOWN_ERROR;
-
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
@@ -41,6 +36,8 @@ import io.mosip.kernel.core.logger.spi.Logger;
 import io.mosip.kernel.core.retry.WithRetry;
 import lombok.NoArgsConstructor;
 import reactor.core.publisher.Mono;
+
+import static io.mosip.idrepository.core.constant.IdRepoErrorConstants.*;
 
 /**
  * The Class RestHelper - to send/receive HTTP requests and return the response.
@@ -311,10 +308,19 @@ public class RestHelper {
 			if (e.getStatusCode().is4xxClientError()) {
 				if (e.getRawStatusCode() == HttpStatus.UNAUTHORIZED.value()) {
 					List<ServiceError> errorList = ExceptionUtils.getServiceErrorList(e.getResponseBodyAsString());
+					if (errorList.isEmpty()) {
+						throw new AuthenticationException(AUTHENTICATION_FAILED.getErrorCode(),
+								AUTHENTICATION_FAILED.getErrorMessage(), e.getRawStatusCode());
+					}
 					throw new AuthenticationException(errorList.get(0).getErrorCode(), errorList.get(0).getMessage(),
 							e.getRawStatusCode());
 				} else if (e.getRawStatusCode() == HttpStatus.FORBIDDEN.value()) {
 					List<ServiceError> errorList = ExceptionUtils.getServiceErrorList(e.getResponseBodyAsString());
+					if (errorList.isEmpty()) {
+						throw new IdRepoRetryException(new AuthenticationException(
+								AUTHENTICATION_FAILED.getErrorCode(),
+								AUTHENTICATION_FAILED.getErrorMessage(), e.getRawStatusCode()));
+					}
 					throw new IdRepoRetryException(new AuthenticationException(errorList.get(0).getErrorCode(),
 							errorList.get(0).getMessage(), e.getRawStatusCode()));
 				} else {


### PR DESCRIPTION
⏺ Issues Fixed

  Bug 1 — IndexOutOfBoundsException in RestHelper.handleStatusError

  Root Cause:
  When the audit service returned a 401 Unauthorized response with an empty body, ExceptionUtils.getServiceErrorList() returned an empty list. The code then called errorList.get(0) without checking, throwing
  IndexOutOfBoundsException.

  File changed: id-repository-core/.../helper/RestHelper.java

  Fix: Added an empty-list guard for both the 401 and 403 paths. If the error list is empty, fall back to the AUTHENTICATION_FAILED constant instead of crashing.

  ---
  Bug 2 — Wrong WebClient used → 401 on async/background threads

  Root Cause:
  Two services were constructing RestHelper via its no-args constructor. RestHelper.init() (@PostConstruct) then fell back to the plain webClient bean, which reads the auth token from SecurityContextHolder.
  On async/background threads (credential issuance, scheduled jobs), the SecurityContext is empty → no token → 401 on every downstream REST call (audit, credential, etc.).

  The selfTokenWebClient bean (from kernel-auth-adapter) uses a cached service-to-service JWT and does not depend on SecurityContextHolder, making it safe for all threads.