### PR TITLE
Update THIRD-PARTY-NOTICES to remove incorrect homepage

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -6,6 +6,7 @@ This project includes third-party packages that are distributed under various op
 Package: MOSIP ID Repository
 Version: release-1.3.x
 License: Mozilla Public License 2.0
+Homepage: https://github.com/mosip/id-repository
 ================================================================================
 
 ================================================================================

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -6,7 +6,6 @@ This project includes third-party packages that are distributed under various op
 Package: MOSIP ID Repository
 Version: release-1.3.x
 License: Mozilla Public License 2.0
-Homepage: https://github.com/Rakshithasai123/id-repository
 ================================================================================
 
 ================================================================================


### PR DESCRIPTION
Removed homepage link for MOSIP ID Repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated third-party notices by removing an outdated homepage reference from one package entry.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->