### PR TITLE
MOSIP-45308 - Updated the request body of the Add Identity to consider full schema

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/AddIdentity.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/AddIdentity.java
@@ -29,6 +29,7 @@ import io.mosip.testrig.apirig.dto.TestCaseDTO;
 import io.mosip.testrig.apirig.idrepo.utils.IdRepoArrayHandle;
 import io.mosip.testrig.apirig.idrepo.utils.IdRepoConfigManager;
 import io.mosip.testrig.apirig.idrepo.utils.IdRepoUtil;
+import io.mosip.testrig.apirig.utils.SchemaBasedIdentityTemplateBuilder;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.testrunner.JsonPrecondtion;
@@ -95,11 +96,16 @@ public class AddIdentity extends IdRepoUtil implements ITest {
 			throw new SkipException(
 					GlobalConstants.TARGET_ENV_HEALTH_CHECK_FAILED + HealthChecker.healthCheckFailureMapS);
 		}
+		// Call modifySchemaGenerateHbs first only to populate schema globals (idSchemaVersion,
+		// phoneSchemaRegex) used below; its template is then replaced with the full-schema one.
 		if(testCaseDTO.getEndPoint().contains(GlobalConstants.ADD_IDENTITY_V2_ENDPOINT)) {
-			testCaseDTO.setInputTemplate(AdminTestUtil.modifySchemaGenerateHbsV2(testCaseDTO.isRegenerateHbs()));
+			AdminTestUtil.modifySchemaGenerateHbsV2(testCaseDTO.isRegenerateHbs());
+			testCaseDTO.setInputTemplate(SchemaBasedIdentityTemplateBuilder.buildAddIdentityTemplateV2());
 		} else {
-			testCaseDTO.setInputTemplate(AdminTestUtil.modifySchemaGenerateHbs(testCaseDTO.isRegenerateHbs()));
+			AdminTestUtil.modifySchemaGenerateHbs(testCaseDTO.isRegenerateHbs());
+			testCaseDTO.setInputTemplate(SchemaBasedIdentityTemplateBuilder.buildAddIdentityTemplate());
 		}
+
 		String jsonInput = testCaseDTO.getInput();
 
 		String inputJson = getJsonFromTemplate(jsonInput, testCaseDTO.getInputTemplate(), false);
@@ -162,11 +168,15 @@ public class AddIdentity extends IdRepoUtil implements ITest {
 		if (inputJson.contains("$EMAILVALUE$")) {
 			inputJson = replaceKeywordWithValue(inputJson, "$EMAILVALUE$", email);
 		}
-		// Replace handle-array tokens before manipulating handle values so that
-		// applyWithDuplicateValue saves/restores the actual resolved values, not tokens.
+		// Resolve $HANDLEVALUE tokens before IdRepoArrayHandle runs so its mutations see real values.
+		inputJson = IdRepoUtil.resolveGenericHandleValueTokens(inputJson);
 		JSONObject jsonString = new JSONObject(inputJson);
 		if (jsonString.getJSONObject("request").getJSONObject("identity").has("selectedHandles")) {
 			inputJson = IdRepoArrayHandle.replaceArrayHandleValues(inputJson, testCaseName);
+		}
+		// Done here (not the handle dispatch) so it also runs on schemas with no handles.
+		if (testCaseName.contains("_extraNonSchemaField")) {
+			inputJson = IdRepoArrayHandle.injectExtraNonSchemaField(inputJson);
 		}
 
 		response = postWithBodyAndCookie(ApplnURI + testCaseDTO.getEndPoint(), inputJson, COOKIENAME,

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/AddIdentity.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/AddIdentity.java
@@ -96,8 +96,7 @@ public class AddIdentity extends IdRepoUtil implements ITest {
 			throw new SkipException(
 					GlobalConstants.TARGET_ENV_HEALTH_CHECK_FAILED + HealthChecker.healthCheckFailureMapS);
 		}
-		// Call modifySchemaGenerateHbs first only to populate schema globals (idSchemaVersion,
-		// phoneSchemaRegex) used below; its template is then replaced with the full-schema one.
+		// modifySchemaGenerateHbs is called only to populate schema globals used below; its template is replaced.
 		if(testCaseDTO.getEndPoint().contains(GlobalConstants.ADD_IDENTITY_V2_ENDPOINT)) {
 			AdminTestUtil.modifySchemaGenerateHbsV2(testCaseDTO.isRegenerateHbs());
 			testCaseDTO.setInputTemplate(SchemaBasedIdentityTemplateBuilder.buildAddIdentityTemplateV2());

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/UpdateIdentityForArrayHandles.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/UpdateIdentityForArrayHandles.java
@@ -93,8 +93,7 @@ public class UpdateIdentityForArrayHandles extends IdRepoUtil implements ITest {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = IdRepoUtil.isTestCaseValidForExecution(testCaseDTO);
 		
-		// Call updateIdentityHbs first only to populate schema globals (idSchemaVersion,
-		// phoneSchemaRegex) used below; its template is then replaced with the full-schema one.
+		// updateIdentityHbs is called only to populate schema globals used below; its template is replaced.
 		if(testCaseDTO.getEndPoint().contains(GlobalConstants.ADD_IDENTITY_V2_ENDPOINT)) {
 			AdminTestUtil.updateIdentityHbsV2(testCaseDTO.isRegenerateHbs());
 			testCaseDTO.setInputTemplate(SchemaBasedIdentityTemplateBuilder.buildUpdateIdentityTemplateV2());

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/UpdateIdentityForArrayHandles.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/testscripts/UpdateIdentityForArrayHandles.java
@@ -26,6 +26,7 @@ import io.mosip.testrig.apirig.dto.TestCaseDTO;
 import io.mosip.testrig.apirig.idrepo.utils.IdRepoArrayHandle;
 import io.mosip.testrig.apirig.idrepo.utils.IdRepoConfigManager;
 import io.mosip.testrig.apirig.idrepo.utils.IdRepoUtil;
+import io.mosip.testrig.apirig.utils.SchemaBasedIdentityTemplateBuilder;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.utils.AdminTestException;
@@ -92,10 +93,14 @@ public class UpdateIdentityForArrayHandles extends IdRepoUtil implements ITest {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = IdRepoUtil.isTestCaseValidForExecution(testCaseDTO);
 		
+		// Call updateIdentityHbs first only to populate schema globals (idSchemaVersion,
+		// phoneSchemaRegex) used below; its template is then replaced with the full-schema one.
 		if(testCaseDTO.getEndPoint().contains(GlobalConstants.ADD_IDENTITY_V2_ENDPOINT)) {
-			testCaseDTO.setInputTemplate(AdminTestUtil.updateIdentityHbsV2(testCaseDTO.isRegenerateHbs()));
+			AdminTestUtil.updateIdentityHbsV2(testCaseDTO.isRegenerateHbs());
+			testCaseDTO.setInputTemplate(SchemaBasedIdentityTemplateBuilder.buildUpdateIdentityTemplateV2());
 		} else {
-			testCaseDTO.setInputTemplate(AdminTestUtil.updateIdentityHbs(testCaseDTO.isRegenerateHbs()));
+			AdminTestUtil.updateIdentityHbs(testCaseDTO.isRegenerateHbs());
+			testCaseDTO.setInputTemplate(SchemaBasedIdentityTemplateBuilder.buildUpdateIdentityTemplate());
 		}
 		testCaseName = testCaseDTO.getTestCaseName();
 		if (HealthChecker.signalTerminateExecution) {
@@ -164,6 +169,8 @@ public class UpdateIdentityForArrayHandles extends IdRepoUtil implements ITest {
 			writeToCache(getAutogenIdKeyName(testCaseName, "phone"), phonenumber);
 		}
 
+		// Resolve $HANDLEVALUE tokens before IdRepoArrayHandle runs so its mutations see real values.
+		inputJson = IdRepoUtil.resolveGenericHandleValueTokens(inputJson);
 		JSONObject jsonString = new JSONObject(inputJson);
 		if (jsonString.getJSONObject("request").getJSONObject("identity").has("selectedHandles")) {
 			inputJson = IdRepoArrayHandle.replaceArrayHandleValuesForUpdateIdentity(inputJson,testCaseName);

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoArrayHandle.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoArrayHandle.java
@@ -13,11 +13,7 @@ import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.utils.AdminTestUtil;
 
 public class IdRepoArrayHandle {
-	/**
-	 * Handle values captured from a "_save_" test's identity, keyed by field name, replayed later to
-	 * trigger a duplicate-handle rejection (IDR-IDC-014). Keyed per field because a value only collides
-	 * with the same field, and a schema can declare several handles.
-	 */
+	/** Handle values captured from a "_save_" test's identity, replayed to trigger IDR-IDC-014. */
 	private static final Map<String, String> savedHandleValues = new LinkedHashMap<>();
 	public static String RANDOM_ID = "mosip" + BaseTestCase.generateRandomNumberString(2)
 			+ Calendar.getInstance().getTimeInMillis();
@@ -139,10 +135,7 @@ public class IdRepoArrayHandle {
 		return jsonObj.toString();
 	}
 
-	/**
-	 * Adds a field the live schema does not define, for the _extraNonSchemaField test. Driven from the
-	 * test script (not the handle dispatch) so it also runs on schemas with no handles.
-	 */
+	/** Adds a field the live schema does not define, for the _extraNonSchemaField test. */
 	public static String injectExtraNonSchemaField(String inputJson) {
 		JSONObject jsonObj = new JSONObject(inputJson);
 		JSONObject identity = jsonObj.getJSONObject("request").getJSONObject("identity");
@@ -472,11 +465,7 @@ public class IdRepoArrayHandle {
 		writeHandleValue(identity, handle, INVALID_HANDLE_VALUE);
 	}
 
-	/**
-	 * Reads a handle's value irrespective of how the schema types it: a "type": "string" handle
-	 * (e.g. licenseNo) holds the value directly, a "type": "array" handle (e.g. functionalId) holds
-	 * it as [{value, tags}]. Returns null when the field is absent or carries no value.
-	 */
+	/** Reads a handle's value regardless of schema shape (string, or array of {value,tags}); null if absent. */
 	private static String readHandleValue(JSONObject identity, String handle) {
 		Object handleObj = identity.opt(handle);
 		if (handleObj instanceof JSONArray) {
@@ -508,8 +497,7 @@ public class IdRepoArrayHandle {
 		}
 	}
 
-	/** Records the identity's current handle values (from the schema's handle list, so string-typed
-	 *  handles are captured too) for a later test to replay. */
+	/** Records the identity's current handle values for a later test to replay. */
 	private static void saveHandleValues(JSONObject identity) {
 		for (String handle : resolveSchemaHandleFields()) {
 			String value = readHandleValue(identity, handle);

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoArrayHandle.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoArrayHandle.java
@@ -3,7 +3,9 @@ package io.mosip.testrig.apirig.idrepo.utils;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -11,7 +13,12 @@ import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.utils.AdminTestUtil;
 
 public class IdRepoArrayHandle {
-	private static String selectedHandlesValue = null;
+	/**
+	 * Handle values captured from a "_save_" test's identity, keyed by field name, replayed later to
+	 * trigger a duplicate-handle rejection (IDR-IDC-014). Keyed per field because a value only collides
+	 * with the same field, and a schema can declare several handles.
+	 */
+	private static final Map<String, String> savedHandleValues = new LinkedHashMap<>();
 	public static String RANDOM_ID = "mosip" + BaseTestCase.generateRandomNumberString(2)
 			+ Calendar.getInstance().getTimeInMillis();
 
@@ -47,13 +54,13 @@ public class IdRepoArrayHandle {
 		}
 		if (testCaseName.contains("_withNotApplicableSelectedHandles")) {
 		    JSONArray selectedHandles = new JSONArray();
-		    selectedHandles.put("fullName");
+		    selectedHandles.put(resolveNonHandleSchemaField());
 		    identity.put("selectedHandles", selectedHandles);
 		    return jsonObj.toString();
 		}
 		if (testCaseName.contains("_withUnknownSelectedHandles")) {
 		    JSONArray selectedHandles = new JSONArray();
-		    selectedHandles.put("passport");
+		    selectedHandles.put(resolveFieldNotInSchema());
 		    identity.put("selectedHandles", selectedHandles);
 		    return jsonObj.toString();
 		}
@@ -92,6 +99,31 @@ public class IdRepoArrayHandle {
 			applyWithSelectedHandlePhone(identity);
 			return jsonObj.toString();
 		}
+		// Field-agnostic negative scenarios; the target handle is resolved from the schema and is
+		// guaranteed present here (the matching capability skip in IdRepoUtil ran first).
+		if (testCaseName.contains("_missingRequiredHandle")) {
+			removeHandleFromIdentity(identity, IdRepoUtil.resolveRequiredHandle());
+			return jsonObj.toString();
+		}
+		if (testCaseName.contains("_invalidStringHandleValue")) {
+			setInvalidHandleValue(identity, IdRepoUtil.resolveHandleOfType("string"));
+			return jsonObj.toString();
+		}
+		if (testCaseName.contains("_invalidArrayHandleValue")) {
+			setInvalidHandleValue(identity, IdRepoUtil.resolveHandleOfType("array"));
+			return jsonObj.toString();
+		}
+		// Save/replay run outside the per-handle loop below, which only visits array-typed handles —
+		// these two must also cover string-typed handles (e.g. licenseNo).
+		// _save_withdublicatevalue contains _withdublicatevalue, so it must be checked first.
+		if (testCaseName.contains("_save_withdublicatevalue")) {
+			saveHandleValues(identity);
+			return jsonObj.toString();
+		}
+		if (testCaseName.contains("_withdublicatevalue")) {
+			applySavedHandleValues(identity);
+			return jsonObj.toString();
+		}
 
 		JSONArray selectedHandles = identity.getJSONArray("selectedHandles");
 		for (int i = 0; i < selectedHandles.length(); i++) {
@@ -104,6 +136,17 @@ public class IdRepoArrayHandle {
 			applyAddIdentityHandleMutation(testCaseName, identity, selectedHandles, handle, handleArray);
 			identity.put(handle, handleArray);
 		}
+		return jsonObj.toString();
+	}
+
+	/**
+	 * Adds a field the live schema does not define, for the _extraNonSchemaField test. Driven from the
+	 * test script (not the handle dispatch) so it also runs on schemas with no handles.
+	 */
+	public static String injectExtraNonSchemaField(String inputJson) {
+		JSONObject jsonObj = new JSONObject(inputJson);
+		JSONObject identity = jsonObj.getJSONObject("request").getJSONObject("identity");
+		identity.put(resolveFieldNotInSchema(), "extraFieldValue");
 		return jsonObj.toString();
 	}
 
@@ -188,6 +231,20 @@ public class IdRepoArrayHandle {
 			// $ID: tokens put here would not be resolved by the framework at this stage.
 			return jsonObj.toString();
 		}
+		// Replays the handle values of the identity created by the "_save_" AddIdentity test onto
+		// this (different) identity, so every schema-declared handle collides with an existing one
+		// and the server must reject the update with IDR-IDC-014. Runs outside the per-handle loop
+		// below so string-typed handles are covered too.
+		// _withusedhandlevaluewithoutselectedhandles contains _withusedhandlevalue — check it first.
+		if (testCaseName.contains("_withusedhandlevaluewithoutselectedhandles")) {
+			applySavedHandleValues(identity);
+			identity.remove("selectedHandles");
+			return jsonObj.toString();
+		}
+		if (testCaseName.contains("_withusedhandlevalue")) {
+			applySavedHandleValues(identity);
+			return jsonObj.toString();
+		}
 
 		JSONArray selectedHandles = identity.getJSONArray("selectedHandles");
 		for (int i = 0; i < selectedHandles.length(); i++) {
@@ -247,13 +304,13 @@ public class IdRepoArrayHandle {
 		} else if (testCaseName.contains("_WithMultipleEmailHandlesTagged")
 		        && handle.equals(resolveEmailFieldName())) {
 		    applyMultipleEmailHandlesTagged(handleArray);
-		} else if (testCaseName.contains("_withfunctionalIdsUsedFirstTwoValueOutOfFive") && handle.equals("functionalId")) {
-			applyFunctionalIdsUsedFirstTwoValueOutOfFive(handleArray);
-		} else if (testCaseName.contains("_withfunctionalIdsUsedFirstTwoValue") && handle.equals("functionalId")) {
-			applyFunctionalIdsUsedFirstTwoValue(handleArray);
+		} else if (testCaseName.contains("_withfunctionalIdsUsedFirstTwoValueOutOfFive") && isArrayHandle(handle)) {
+			applyFunctionalIdsUsedFirstTwoValueOutOfFive(handleArray, handle);
+		} else if (testCaseName.contains("_withfunctionalIdsUsedFirstTwoValue") && isArrayHandle(handle)) {
+			applyFunctionalIdsUsedFirstTwoValue(handleArray, handle);
 		} else if (testCaseName.contains("_withfunctionalIdsandPhoneWithoutTags")) {
-			applyFunctionalIdsAndPhoneWithoutTags(identity, selectedHandles, handleArray);
-		} else if (testCaseName.contains("_withfunctionalIds") && handle.equals("functionalId")) {
+			applyFunctionalIdsAndPhoneWithoutTags(handleArray);
+		} else if (testCaseName.contains("_withfunctionalIds") && isArrayHandle(handle)) {
 			applyFunctionalIds(handleArray);
 		} else if (testCaseName.contains("_removeexceptfirsthandle")) {
 			applyRemoveExceptFirstHandle(identity, selectedHandles, handle);
@@ -264,11 +321,9 @@ public class IdRepoArrayHandle {
 		} else if (testCaseName.contains("_withcasesensitivehandles")) {
 			applyWithCaseSensitiveHandles(handleArray);
 		} else if (testCaseName.contains("_withmultipledublicatevalue")) {
-			applyWithMultipleDuplicateValue(handleArray);
-		} else if (testCaseName.contains("_withdublicatevalue")) {
-			applyWithDuplicateValue(testCaseName, handleArray);
+			applyWithMultipleDuplicateValue(handleArray, handle);
 		} else if (testCaseName.contains("_removevalueaddexistingvalue")) {
-			applyRemoveValueAddExistingValue(handleArray);
+			applyRemoveValueAddExistingValue(handleArray, handle);
 		} else {
 			for (int j = 0; j < handleArray.length(); j++) {
 				JSONObject obj = handleArray.getJSONObject(j);
@@ -330,16 +385,6 @@ public class IdRepoArrayHandle {
 			applyRemoveSelectedHandleUpdatePhone(identity, phoneFieldName);
 		} else if (testCaseName.contains("_withinvaliddhandle")) {
 			selectedHandles.put("newFieldHandle");
-		} else if (testCaseName.contains("_withusedphone")) {
-			if (identity.has(phoneFieldName)) {
-				identity.put(phoneFieldName,
-						"$ID:AddIdentity_array_handle_value_smoke_Pos_withphonenumber_PHONE$");
-			}
-		} else if (testCaseName.contains("_withphonevalue")) {
-			if (identity.has(phoneFieldName)) {
-				identity.put(phoneFieldName,
-						"$ID:AddIdentity_array_handle_value_smoke_Pos_withselectedhandlephone_PHONE$");
-			}
 		}
 	}
 
@@ -348,6 +393,139 @@ public class IdRepoArrayHandle {
 	private static String resolvePhoneFieldName() {
 		String phone = AdminTestUtil.getValueFromAuthActuator("json-property", "phone_number");
 		return phone.replaceAll("\\[\"|\"]", "");
+	}
+
+	/** Handle fields declared by the live IdSchema ("handle":true), e.g. [licenseNo, functionalId]. */
+	private static List<String> resolveSchemaHandleFields() {
+		JSONObject props = AdminTestUtil.getIdentitySchemaProperties();
+		List<String> handleFields = new ArrayList<>();
+		for (String fieldName : props.keySet()) {
+			if (props.getJSONObject(fieldName).optBoolean("handle", false)) {
+				handleFields.add(fieldName);
+			}
+		}
+		return handleFields;
+	}
+
+	/** True when the given field is an array-typed handle in the live schema (e.g. functionalId). */
+	private static boolean isArrayHandle(String handle) {
+		JSONObject props = AdminTestUtil.getIdentitySchemaProperties();
+		if (!props.has(handle)) {
+			return false;
+		}
+		JSONObject fieldDef = props.getJSONObject(handle);
+		return fieldDef.optBoolean("handle", false) && "array".equals(fieldDef.optString("type", "string"));
+	}
+
+	/** A schema field that exists but is NOT a handle (for the not-applicable-selectedHandle test). */
+	private static String resolveNonHandleSchemaField() {
+		JSONObject props = AdminTestUtil.getIdentitySchemaProperties();
+		for (String fieldName : props.keySet()) {
+			if (fieldName.equals("UIN") || fieldName.equals("selectedHandles")
+					|| fieldName.equals("IDSchemaVersion")) {
+				continue;
+			}
+			if (!props.getJSONObject(fieldName).optBoolean("handle", false)) {
+				return fieldName;
+			}
+		}
+		return "fullName";
+	}
+
+	/** A field name generated and verified NOT present in the live schema (for the unknown-field test). */
+	private static String resolveFieldNotInSchema() {
+		JSONObject props = AdminTestUtil.getIdentitySchemaProperties();
+		String candidate;
+		do {
+			candidate = "notASchemaField" + BaseTestCase.generateRandomNumberString(6);
+		} while (props.has(candidate));
+		return candidate;
+	}
+
+	// A value engineered to violate the typical handle validator (email / phone / alphanumeric-ID
+	// regexes) — it contains spaces and special characters that anchored patterns reject.
+	private static final String INVALID_HANDLE_VALUE = "in valid!@# value";
+
+	/** Removes a handle field from both the identity body and the selectedHandles array. */
+	private static void removeHandleFromIdentity(JSONObject identity, String handle) {
+		if (handle == null) {
+			return;
+		}
+		identity.remove(handle);
+		if (identity.has("selectedHandles") && identity.get("selectedHandles") instanceof JSONArray) {
+			JSONArray selectedHandles = identity.getJSONArray("selectedHandles");
+			JSONArray remaining = new JSONArray();
+			for (int i = 0; i < selectedHandles.length(); i++) {
+				if (!handle.equals(selectedHandles.getString(i))) {
+					remaining.put(selectedHandles.getString(i));
+				}
+			}
+			identity.put("selectedHandles", remaining);
+		}
+	}
+
+	/** Sets a handle's value to one that violates its validator, honouring the schema's string/array shape. */
+	private static void setInvalidHandleValue(JSONObject identity, String handle) {
+		if (handle == null) {
+			return;
+		}
+		writeHandleValue(identity, handle, INVALID_HANDLE_VALUE);
+	}
+
+	/**
+	 * Reads a handle's value irrespective of how the schema types it: a "type": "string" handle
+	 * (e.g. licenseNo) holds the value directly, a "type": "array" handle (e.g. functionalId) holds
+	 * it as [{value, tags}]. Returns null when the field is absent or carries no value.
+	 */
+	private static String readHandleValue(JSONObject identity, String handle) {
+		Object handleObj = identity.opt(handle);
+		if (handleObj instanceof JSONArray) {
+			JSONArray handleArray = (JSONArray) handleObj;
+			for (int i = 0; i < handleArray.length(); i++) {
+				JSONObject entry = handleArray.optJSONObject(i);
+				if (entry != null && entry.has("value")) {
+					return entry.getString("value");
+				}
+			}
+			return null;
+		}
+		return handleObj instanceof String ? (String) handleObj : null;
+	}
+
+	/** Counterpart to {@link #readHandleValue}: writes into whichever shape the schema defines. */
+	private static void writeHandleValue(JSONObject identity, String handle, String value) {
+		Object handleObj = identity.opt(handle);
+		if (handleObj instanceof JSONArray) {
+			JSONArray handleArray = (JSONArray) handleObj;
+			for (int i = 0; i < handleArray.length(); i++) {
+				JSONObject entry = handleArray.optJSONObject(i);
+				if (entry != null) {
+					entry.put("value", value);
+				}
+			}
+		} else if (handleObj != null) {
+			identity.put(handle, value);
+		}
+	}
+
+	/** Records the identity's current handle values (from the schema's handle list, so string-typed
+	 *  handles are captured too) for a later test to replay. */
+	private static void saveHandleValues(JSONObject identity) {
+		for (String handle : resolveSchemaHandleFields()) {
+			String value = readHandleValue(identity, handle);
+			if (value != null) {
+				savedHandleValues.put(handle, value);
+			}
+		}
+	}
+
+	/** Replays {@link #savedHandleValues} onto this identity so each handle duplicates an existing one. */
+	private static void applySavedHandleValues(JSONObject identity) {
+		for (Map.Entry<String, String> saved : savedHandleValues.entrySet()) {
+			if (identity.has(saved.getKey())) {
+				writeHandleValue(identity, saved.getKey(), saved.getValue());
+			}
+		}
 	}
 
 	private static String resolveEmailFieldName() {
@@ -437,11 +615,11 @@ public class IdRepoArrayHandle {
 	    }
 	}
 	
-	private static void applyFunctionalIdsUsedFirstTwoValueOutOfFive(JSONArray handleArray) {
-		String baseValue = handleArray.length() > 0 ? handleArray.getJSONObject(0).getString("value") : "";
+	private static void applyFunctionalIdsUsedFirstTwoValueOutOfFive(JSONArray handleArray, String handle) {
+		// Positive: five entries, only the first tagged; values generated to satisfy the handle validator.
 		for (int j = 0; j < 4; j++) {
 			JSONObject obj = new JSONObject();
-			obj.put("value", baseValue + j);
+			obj.put("value", IdRepoUtil.generateSchemaFieldValue(handle));
 			if (j < 1) {
 				obj.put("tags", new JSONArray().put("handle"));
 			}
@@ -556,34 +734,21 @@ public class IdRepoArrayHandle {
 	    handleArray.put(newEmail);
 	}
 
-	private static void applyFunctionalIdsUsedFirstTwoValue(JSONArray handleArray) {
+	private static void applyFunctionalIdsUsedFirstTwoValue(JSONArray handleArray, String handle) {
 		if (handleArray.length() < 3) {
+			// Positive: appended values generated to satisfy the handle's own validator.
 			JSONObject secondValue = new JSONObject();
-			secondValue.put("value", "RANDOM_ID_2" + 12);
+			secondValue.put("value", IdRepoUtil.generateSchemaFieldValue(handle));
 			secondValue.put("tags", new JSONArray().put("handle"));
 			JSONObject thirdValue = new JSONObject();
-			thirdValue.put("value", "RANDOM_ID_2" + 34);
+			thirdValue.put("value", IdRepoUtil.generateSchemaFieldValue(handle));
 			handleArray.put(secondValue);
 			handleArray.put(thirdValue);
 		}
 	}
 
-	private static void applyFunctionalIdsAndPhoneWithoutTags(JSONObject identity, JSONArray selectedHandles,
-			JSONArray handleArray) {
-		String phoneFieldName = resolvePhoneFieldName();
-		boolean containsPhone = false;
-		for (int j = 0; j < selectedHandles.length(); j++) {
-			if (phoneFieldName.equalsIgnoreCase(selectedHandles.getString(j))) {
-				containsPhone = true;
-				break;
-			}
-		}
-		if (!containsPhone) {
-			selectedHandles.put(phoneFieldName);
-			JSONObject phoneEntry = new JSONObject();
-			phoneEntry.put("value", "$PHONENUMBERFORIDENTITY$");
-			identity.put(phoneFieldName, new JSONArray().put(phoneEntry));
-		}
+	private static void applyFunctionalIdsAndPhoneWithoutTags(JSONArray handleArray) {
+		// Gated [functionalId, phone]; both are already handles in the body — just strip the tags.
 		for (int j = 0; j < handleArray.length(); j++) {
 			handleArray.getJSONObject(j).remove("tags");
 		}
@@ -634,46 +799,30 @@ public class IdRepoArrayHandle {
 	}
 
 	private static void applyWithSelectedHandlePhone(JSONObject identity) {
-		JSONArray updatedHandles = new JSONArray();
-		boolean containsPhone = false;
-		if (identity.has("selectedHandles")) {
-			JSONArray selectedHandles = identity.getJSONArray("selectedHandles");
-			for (int j = 0; j < selectedHandles.length(); j++) {
-				String h = selectedHandles.getString(j);
-				if (h.equalsIgnoreCase("phone")) {
-					containsPhone = true;
-					updatedHandles.put("phone");
-				}
-			}
-		}
-		if (!containsPhone) {
-			updatedHandles.put("phone");
-		}
-		identity.put("selectedHandles", updatedHandles);
+		// Gated [phone]; reduce selectedHandles to just phone (resolved name, not a literal).
+		identity.put("selectedHandles", new JSONArray().put(resolvePhoneFieldName()));
 	}
 
-	private static void applyWithMultipleDuplicateValue(JSONArray handleArray) {
+	private static void applyWithMultipleDuplicateValue(JSONArray handleArray, String handle) {
+		String savedValue = savedHandleValues.get(handle);
+		if (savedValue == null) {
+			return;
+		}
 		JSONObject secondValue = new JSONObject();
-		secondValue.put("value", selectedHandlesValue);
+		secondValue.put("value", savedValue);
 		secondValue.put("tags", new JSONArray().put("handle"));
 		handleArray.put(secondValue);
 	}
 
-	private static void applyWithDuplicateValue(String testCaseName, JSONArray handleArray) {
-		for (int j = 0; j < handleArray.length(); j++) {
-			JSONObject obj = handleArray.getJSONObject(j);
-			if (testCaseName.contains("_save_withdublicatevalue")) {
-				selectedHandlesValue = obj.getString("value");
-			}
-			obj.put("value", selectedHandlesValue);
+	private static void applyRemoveValueAddExistingValue(JSONArray handleArray, String handle) {
+		String savedValue = savedHandleValues.get(handle);
+		if (savedValue == null) {
+			return;
 		}
-	}
-
-	private static void applyRemoveValueAddExistingValue(JSONArray handleArray) {
 		for (int j = 0; j < handleArray.length(); j++) {
 			JSONObject obj = handleArray.getJSONObject(j);
 			obj.remove("value");
-			obj.put("value", selectedHandlesValue);
+			obj.put("value", savedValue);
 		}
 	}
 
@@ -684,7 +833,8 @@ public class IdRepoArrayHandle {
 			if (handle.equals(emailFieldName)) {
 				handleArray.getJSONObject(j).put("value", "mosip_update_" + RANDOM_ID + "@mosip.net");
 			} else {
-				handleArray.getJSONObject(j).put("value", "mosip" + RANDOM_ID + "_" + j);
+				// Positive update — new value generated to satisfy the handle's own validator.
+				handleArray.getJSONObject(j).put("value", IdRepoUtil.generateSchemaFieldValue(handle));
 			}
 		}
 	}
@@ -757,31 +907,33 @@ public class IdRepoArrayHandle {
 
 	private static void applyWithUpdatedSelectedHandleAndFirstAttribute(JSONObject identity,
 			JSONArray selectedHandles) {
+		// Pick the first array-valued attribute to corrupt; skip selectedHandles and any string/scalar
+		// field (e.g. the string-typed handle licenseNo), which would throw on getJSONArray.
 		Iterator<String> keys = identity.keys();
-		if (keys.hasNext()) {
+		while (keys.hasNext()) {
 			String firstKey = keys.next();
-			if (!firstKey.equals("selectedHandles")) {
-				selectedHandles.put(0, firstKey);
-				if (identity.has(firstKey)) {
-					JSONArray originalArray = identity.getJSONArray(firstKey);
-					for (int j = 0; j < originalArray.length(); j++) {
-						JSONObject handleObject = originalArray.getJSONObject(j);
-						if (handleObject.has("value")) {
-							handleObject.put("value", handleObject.getString("value") + "123");
-						}
-						if (handleObject.has("tags")) {
-							JSONArray tagsArray = handleObject.getJSONArray("tags");
-							for (int k = 0; k < tagsArray.length(); k++) {
-								tagsArray.put(k, tagsArray.getString(k) + "123");
-							}
-							handleObject.put("tags", tagsArray);
-						}
-						originalArray.put(j, handleObject);
-					}
-					identity.remove(firstKey);
-					identity.put(firstKey, originalArray);
-				}
+			if (firstKey.equals("selectedHandles") || !(identity.get(firstKey) instanceof JSONArray)) {
+				continue;
 			}
+			selectedHandles.put(0, firstKey);
+			JSONArray originalArray = identity.getJSONArray(firstKey);
+			for (int j = 0; j < originalArray.length(); j++) {
+				JSONObject handleObject = originalArray.getJSONObject(j);
+				if (handleObject.has("value")) {
+					handleObject.put("value", handleObject.getString("value") + "123");
+				}
+				if (handleObject.has("tags")) {
+					JSONArray tagsArray = handleObject.getJSONArray("tags");
+					for (int k = 0; k < tagsArray.length(); k++) {
+						tagsArray.put(k, tagsArray.getString(k) + "123");
+					}
+					handleObject.put("tags", tagsArray);
+				}
+				originalArray.put(j, handleObject);
+			}
+			identity.remove(firstKey);
+			identity.put(firstKey, originalArray);
+			break;
 		}
 	}
 

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoUtil.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.json.JSONArray;
+import org.json.JSONObject;
 import org.testng.SkipException;
 
 import io.mosip.testrig.apirig.dbaccess.DBManager;
@@ -51,14 +52,47 @@ public class IdRepoUtil extends AdminTestUtil {
 			throw new SkipException(GlobalConstants.KNOWN_ISSUES);
 		}
 
+		// The schema-conditional skips below use FEATURE_NOT_SUPPORTED_MESSAGE so EmailableReport routes
+		// them to the Ignored bucket (it matches on that phrase), not Skipped.
 		if (testCaseDTO.getRequiredSchemaFields() != null && testCaseDTO.getRequiredSchemaFields().length > 0) {
 			for (String field : testCaseDTO.getRequiredSchemaFields()) {
 				String trimmed = field.trim();
 				if (globalRequiredFields == null || !isElementPresent(globalRequiredFields, trimmed)) {
-					throw new SkipException(
-							"Schema field '" + trimmed + "' not present in current IdSchema — test not applicable");
+					throw new SkipException("Schema field '" + trimmed + "' not present in current IdSchema — "
+							+ GlobalConstants.FEATURE_NOT_SUPPORTED_MESSAGE);
 				}
 			}
+		}
+
+		// Skip-only handle gate: skip a test whose listed field isn't a handle in the live schema.
+		if (testCaseDTO.getRequiredHandleFields() != null && testCaseDTO.getRequiredHandleFields().length > 0) {
+			JSONObject identityProps = AdminTestUtil.getIdentitySchemaProperties();
+			for (String field : testCaseDTO.getRequiredHandleFields()) {
+				String trimmed = field.trim();
+				if (!isFieldHandleCapable(identityProps, trimmed)) {
+					throw new SkipException("Schema field '" + trimmed + "' is not a handle in the current IdSchema — "
+							+ GlobalConstants.FEATURE_NOT_SUPPORTED_MESSAGE);
+				}
+			}
+		}
+
+		// Schema-capability skips for the generic (field-name-agnostic) handle scenarios. Each test
+		// declares the capability it needs via its name; if the live schema can't support it, skip.
+		if (testCaseName.contains("_missingRequiredHandle") && !schemaHasRequiredHandle()) {
+			throw new SkipException(
+					"No required handle field in the current IdSchema — " + GlobalConstants.FEATURE_NOT_SUPPORTED_MESSAGE);
+		}
+		if (testCaseName.contains("_invalidStringHandleValue") && !schemaHasHandleOfType("string")) {
+			throw new SkipException(
+					"No string-typed handle in the current IdSchema — " + GlobalConstants.FEATURE_NOT_SUPPORTED_MESSAGE);
+		}
+		if (testCaseName.contains("_invalidArrayHandleValue") && !schemaHasHandleOfType("array")) {
+			throw new SkipException(
+					"No array-typed handle in the current IdSchema — " + GlobalConstants.FEATURE_NOT_SUPPORTED_MESSAGE);
+		}
+		if (testCaseName.contains("_extraNonSchemaField") && schemaAllowsAdditionalProperties()) {
+			throw new SkipException("Schema permits additional properties, unknown-field rejection not applicable — "
+					+ GlobalConstants.FEATURE_NOT_SUPPORTED_MESSAGE);
 		}
 
 		JSONArray dobArray = new JSONArray(getValueFromAuthActuator("json-property", "dob"));
@@ -72,7 +106,7 @@ public class IdRepoUtil extends AdminTestUtil {
 		}
 
 		if (testCaseName.startsWith("IdRepository_") && testCaseName.contains("_handle")
-				&& foundHandlesInIdSchema == false) {
+				&& !schemaHasAnyHandle()) {
 			throw new SkipException(GlobalConstants.FEATURE_NOT_SUPPORTED_MESSAGE);
 		}
 
@@ -89,7 +123,17 @@ public class IdRepoUtil extends AdminTestUtil {
 
 		return testCaseName;
 	}
-	
+
+	/** True when the named field exists in the schema and is declared "handle": true (case-insensitive). */
+	private static boolean isFieldHandleCapable(JSONObject identityProps, String fieldName) {
+		for (String key : identityProps.keySet()) {
+			if (key.equalsIgnoreCase(fieldName)) {
+				return identityProps.getJSONObject(key).optBoolean("handle", false);
+			}
+		}
+		return false;
+	}
+
 	public static void dbCleanUp() {
 		DBManager.executeDBQueries(IdRepoConfigManager.getKMDbUrl(), IdRepoConfigManager.getKMDbUser(),
 				IdRepoConfigManager.getKMDbPass(), IdRepoConfigManager.getKMDbSchema(),
@@ -116,5 +160,80 @@ public class IdRepoUtil extends AdminTestUtil {
 			jsonString = replaceKeywordWithValue(jsonString, "$RIDEXT$", genRidExt);
 		return jsonString;
 	}
-	
+
+	/**
+	 * Resolves $HANDLEVALUE:<fieldName>$ tokens emitted by the full-schema builder for optional handle
+	 * fields. Delegates to the shared implementation in {@link AdminTestUtil}.
+	 */
+	public static String resolveGenericHandleValueTokens(String jsonString) {
+		return AdminTestUtil.resolveSchemaHandleValueTokens(jsonString);
+	}
+
+	/**
+	 * Generates a value satisfying the given schema field's own validator. Delegates to the shared
+	 * implementation in {@link AdminTestUtil}; kept as a thin wrapper so idrepo callers (e.g.
+	 * IdRepoArrayHandle handle-value mutations) don't need to change.
+	 */
+	public static String generateSchemaFieldValue(String fieldName) {
+		return AdminTestUtil.generateSchemaFieldValue(fieldName);
+	}
+
+	/**
+	 * True when the live IdSchema declares at least one handle field. Computed directly from the
+	 * schema rather than relying on a flag that a template build sets as a side effect, so the
+	 * _handle skip gate is correct regardless of suite order or a narrowed testCasesToExecute run.
+	 */
+	public static boolean schemaHasAnyHandle() {
+		JSONObject props = AdminTestUtil.getIdentitySchemaProperties();
+		for (String fieldName : props.keySet()) {
+			if (props.getJSONObject(fieldName).optBoolean("handle", false)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/** True when the schema declares at least one handle field of the given "type" ("string"/"array"). */
+	public static boolean schemaHasHandleOfType(String type) {
+		return resolveHandleOfType(type) != null;
+	}
+
+	/** First handle field of the given schema "type", or null if none — schema-driven, no field names. */
+	public static String resolveHandleOfType(String type) {
+		JSONObject props = AdminTestUtil.getIdentitySchemaProperties();
+		for (String fieldName : props.keySet()) {
+			JSONObject fieldDef = props.getJSONObject(fieldName);
+			if (fieldDef.optBoolean("handle", false) && type.equals(fieldDef.optString("type", "string"))) {
+				return fieldName;
+			}
+		}
+		return null;
+	}
+
+	/** True when the schema declares a handle field that is also in its "required" array. */
+	public static boolean schemaHasRequiredHandle() {
+		return resolveRequiredHandle() != null;
+	}
+
+	/** First handle field that is also required, or null if none. */
+	public static String resolveRequiredHandle() {
+		JSONObject props = AdminTestUtil.getIdentitySchemaProperties();
+		for (String fieldName : props.keySet()) {
+			if (props.getJSONObject(fieldName).optBoolean("handle", false)
+					&& isElementPresent(globalRequiredFields, fieldName)) {
+				return fieldName;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * True when the live schema's identity node permits fields it does not define
+	 * ("additionalProperties": true). Most schemas are strict (false) and reject unknown fields.
+	 */
+	public static boolean schemaAllowsAdditionalProperties() {
+		AdminTestUtil.getIdentitySchemaProperties(); // ensure the flag is populated
+		return Boolean.TRUE.equals(AdminTestUtil.globalIdentityAdditionalProperties);
+	}
+
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoUtil.java
@@ -161,28 +161,17 @@ public class IdRepoUtil extends AdminTestUtil {
 		return jsonString;
 	}
 
-	/**
-	 * Resolves $HANDLEVALUE:<fieldName>$ tokens emitted by the full-schema builder for optional handle
-	 * fields. Delegates to the shared implementation in {@link AdminTestUtil}.
-	 */
+	/** Resolves $HANDLEVALUE:&lt;field&gt;$ tokens; delegates to {@link AdminTestUtil}. */
 	public static String resolveGenericHandleValueTokens(String jsonString) {
 		return AdminTestUtil.resolveSchemaHandleValueTokens(jsonString);
 	}
 
-	/**
-	 * Generates a value satisfying the given schema field's own validator. Delegates to the shared
-	 * implementation in {@link AdminTestUtil}; kept as a thin wrapper so idrepo callers (e.g.
-	 * IdRepoArrayHandle handle-value mutations) don't need to change.
-	 */
+	/** Generates a value satisfying the given schema field's validator; delegates to {@link AdminTestUtil}. */
 	public static String generateSchemaFieldValue(String fieldName) {
 		return AdminTestUtil.generateSchemaFieldValue(fieldName);
 	}
 
-	/**
-	 * True when the live IdSchema declares at least one handle field. Computed directly from the
-	 * schema rather than relying on a flag that a template build sets as a side effect, so the
-	 * _handle skip gate is correct regardless of suite order or a narrowed testCasesToExecute run.
-	 */
+	/** True when the live IdSchema declares at least one handle field. */
 	public static boolean schemaHasAnyHandle() {
 		JSONObject props = AdminTestUtil.getIdentitySchemaProperties();
 		for (String fieldName : props.keySet()) {
@@ -227,10 +216,7 @@ public class IdRepoUtil extends AdminTestUtil {
 		return null;
 	}
 
-	/**
-	 * True when the live schema's identity node permits fields it does not define
-	 * ("additionalProperties": true). Most schemas are strict (false) and reject unknown fields.
-	 */
+	/** True when the schema's identity node permits fields it does not define ("additionalProperties":true). */
 	public static boolean schemaAllowsAdditionalProperties() {
 		AdminTestUtil.getIdentitySchemaProperties(); // ensure the flag is populated
 		return Boolean.TRUE.equals(AdminTestUtil.globalIdentityAdditionalProperties);

--- a/api-test/src/main/resources/idRepository/AddIdentity/AddIdentity.yml
+++ b/api-test/src/main/resources/idRepository/AddIdentity/AddIdentity.yml
@@ -759,27 +759,27 @@ AddIdentity:
   "registrationId": "$RID$",
   "addressCopy": "Y",
   "biometricReferenceId": "23452353",
- 
+
    "UIN": "$UIN$",
-  
+
   "dateOfBirth": "1992/04/15",
-    
+
   "postalCode": "14022",
   "email": "$REMOVE$",
   "phone": "$PHONENUMBERFORIDENTITY$",
   "referenceIdentityNumber": "6789545678878",
   "version": "v1",
- 
+
    "introducerRID": "212124324784879",
    "introducerUIN": "212124324784879",
-  
+
    "category": "individualBiometrics",
    "requesttime": "$TIMESTAMP$"
 }'
       output: '{
    "errors": [
     {
-      "errorCode": "IDR-IDC-002"
+      "errorCode": "IDR-IDC-001"
     }
   ]
 }'
@@ -908,7 +908,6 @@ AddIdentity:
       description: Creating UIN in Add Identity passing invalid past timestamp
       uniqueIdentifier: TC_IDRepo_AddIdentity_25
       role: testrig
-      checkErrorsOnlyInResponse: true
       restMethod: post
       inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
       outputTemplate: idRepository/error

--- a/api-test/src/main/resources/idRepository/AddIdentity/AddIdentityArrayHandle.yml
+++ b/api-test/src/main/resources/idRepository/AddIdentity/AddIdentityArrayHandle.yml
@@ -427,6 +427,7 @@ AddIdentity:
       endPoint: /idrepository/v1/identity/
       description: Add identity array handle with functionalids as selected handles
       uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandle_14
+      requiredHandleFields: [functionalId]
       role: testrig
       restMethod: post
       inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
@@ -461,6 +462,7 @@ AddIdentity:
       endPoint: /idrepository/v1/identity/
       description: Add identity array handle with functionalids using first two value
       uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandle_15
+      requiredHandleFields: [functionalId]
       role: testrig
       restMethod: post
       inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
@@ -495,6 +497,7 @@ AddIdentity:
       endPoint: /idrepository/v1/identity/
       description: Add identity array handle with functionalids and phone as selected handles without tag
       uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandle_16
+      requiredHandleFields: [functionalId, phone]
       role: testrig
       restMethod: post
       inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
@@ -529,6 +532,7 @@ AddIdentity:
       endPoint: /idrepository/v1/identity/
       description: Add identity array handle with functionalids as selected handles using first two value out of five
       uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandle_17
+      requiredHandleFields: [functionalId]
       role: testrig
       restMethod: post
       inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
@@ -1107,6 +1111,7 @@ AddIdentity:
       endPoint: /idrepository/v1/identity/
       description: Add identity with only email as selected handle
       uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandle_35
+      requiredHandleFields: [email]
       role: testrig
       restMethod: post
       inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
@@ -1141,6 +1146,7 @@ AddIdentity:
       endPoint: /idrepository/v1/identity/
       description: Add identity with only email as selected handle and update with phone and email in update identity
       uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandle_36
+      requiredHandleFields: [email]
       role: testrig
       restMethod: post
       inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
@@ -1425,6 +1431,7 @@ AddIdentity:
       endPoint: /idrepository/v1/identity/
       description: Add identity array handle with selected handle as phone
       uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandle_44
+      requiredHandleFields: [phone]
       role: testrig
       restMethod: post
       inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
@@ -1493,6 +1500,7 @@ AddIdentity:
       endPoint: /idrepository/v1/identity/
       description: Add identity array handle with selected handle as phone
       uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandle_46
+      requiredHandleFields: [phone]
       role: testrig
       restMethod: post
       inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
@@ -1556,4 +1564,165 @@ AddIdentity:
 }'
       output: '{
   "status":"ACTIVATED"
+}'
+   IdRepository_AddIdentity_array_handle_allHandlesValid_smoke_Pos:
+      endPoint: /idrepository/v1/identity/
+      description: Create identity populating every schema-declared handle with valid values - all handles accepted
+      uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandle_48
+      role: testrig
+      restMethod: post
+      inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
+      outputTemplate: idRepository/AddIdentity/addIdentityResult
+      input: '{
+  "value": "$BIOVALUE$",
+  "id": "mosip.id.create",
+  "registrationId": "$RID$",
+  "addressCopy": "Y",
+  "biometricReferenceId": "23452353",
+   "UIN": "$UIN$",
+  "dateOfBirth": "1992/04/15",
+  "postalCode": "14022",
+  "email": "$EMAILVALUE$",
+  "phone": "$PHONENUMBERFORIDENTITY$",
+  "referenceIdentityNumber": "6789545678878",
+  "version": "v1",
+   "introducerRID": "212124324784879",
+   "introducerUIN": "212124324784879",
+   "category": "individualBiometrics",
+   "requesttime": "$TIMESTAMP$"
+}'
+      output: '{
+  "status":"ACTIVATED"
+}'
+   IdRepository_AddIdentity_array_handle_missingRequiredHandle_Neg:
+      endPoint: /idrepository/v1/identity/
+      description: Create identity omitting a required handle field (resolved from the live schema) - server must reject
+      uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandle_49
+      role: testrig
+      restMethod: post
+      inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
+      outputTemplate: idRepository/error
+      input: '{
+  "value": "$BIOVALUE$",
+  "id": "mosip.id.create",
+  "registrationId": "$RID$",
+  "addressCopy": "Y",
+  "biometricReferenceId": "23452353",
+   "UIN": "$UIN$",
+  "dateOfBirth": "1992/04/15",
+  "postalCode": "14022",
+  "email": "$EMAILVALUE$",
+  "phone": "$PHONENUMBERFORIDENTITY$",
+  "referenceIdentityNumber": "6789545678878",
+  "version": "v1",
+   "introducerRID": "212124324784879",
+   "introducerUIN": "212124324784879",
+   "category": "individualBiometrics",
+   "requesttime": "$TIMESTAMP$"
+}'
+      output: '{
+   "errors": [
+    {
+      "errorCode": "IDR-IDC-002"
+    }
+  ]
+}'
+   IdRepository_AddIdentity_array_handle_invalidStringHandleValue_Neg:
+      endPoint: /idrepository/v1/identity/
+      description: Create identity with an invalid value on a string-typed handle (resolved from schema) - server must reject
+      uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandle_50
+      role: testrig
+      restMethod: post
+      inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
+      outputTemplate: idRepository/error
+      input: '{
+  "value": "$BIOVALUE$",
+  "id": "mosip.id.create",
+  "registrationId": "$RID$",
+  "addressCopy": "Y",
+  "biometricReferenceId": "23452353",
+   "UIN": "$UIN$",
+  "dateOfBirth": "1992/04/15",
+  "postalCode": "14022",
+  "email": "$EMAILVALUE$",
+  "phone": "$PHONENUMBERFORIDENTITY$",
+  "referenceIdentityNumber": "6789545678878",
+  "version": "v1",
+   "introducerRID": "212124324784879",
+   "introducerUIN": "212124324784879",
+   "category": "individualBiometrics",
+   "requesttime": "$TIMESTAMP$"
+}'
+      output: '{
+   "errors": [
+    {
+      "errorCode": "IDR-IDC-002"
+    }
+  ]
+}'
+   IdRepository_AddIdentity_array_handle_invalidArrayHandleValue_Neg:
+      endPoint: /idrepository/v1/identity/
+      description: Create identity with an invalid value on an array-typed handle (resolved from schema) - server must reject
+      uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandle_51
+      role: testrig
+      restMethod: post
+      inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
+      outputTemplate: idRepository/error
+      input: '{
+  "value": "$BIOVALUE$",
+  "id": "mosip.id.create",
+  "registrationId": "$RID$",
+  "addressCopy": "Y",
+  "biometricReferenceId": "23452353",
+   "UIN": "$UIN$",
+  "dateOfBirth": "1992/04/15",
+  "postalCode": "14022",
+  "email": "$EMAILVALUE$",
+  "phone": "$PHONENUMBERFORIDENTITY$",
+  "referenceIdentityNumber": "6789545678878",
+  "version": "v1",
+   "introducerRID": "212124324784879",
+   "introducerUIN": "212124324784879",
+   "category": "individualBiometrics",
+   "requesttime": "$TIMESTAMP$"
+}'
+      output: '{
+   "errors": [
+    {
+      "errorCode": "IDR-IDC-002"
+    }
+  ]
+}'
+   IdRepository_AddIdentity_extraNonSchemaField_Neg:
+      endPoint: /idrepository/v1/identity/
+      description: Create identity including a field the schema does not define - strict schema must reject (skipped when schema allows additional properties)
+      uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandle_52
+      role: testrig
+      restMethod: post
+      inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
+      outputTemplate: idRepository/error
+      input: '{
+  "value": "$BIOVALUE$",
+  "id": "mosip.id.create",
+  "registrationId": "$RID$",
+  "addressCopy": "Y",
+  "biometricReferenceId": "23452353",
+   "UIN": "$UIN$",
+  "dateOfBirth": "1992/04/15",
+  "postalCode": "14022",
+  "email": "$EMAILVALUE$",
+  "phone": "$PHONENUMBERFORIDENTITY$",
+  "referenceIdentityNumber": "6789545678878",
+  "version": "v1",
+   "introducerRID": "212124324784879",
+   "introducerUIN": "212124324784879",
+   "category": "individualBiometrics",
+   "requesttime": "$TIMESTAMP$"
+}'
+      output: '{
+   "errors": [
+    {
+      "errorCode": "IDR-IDC-002"
+    }
+  ]
 }'

--- a/api-test/src/main/resources/idRepository/AddIdentityV2/AddIdentityV2.yml
+++ b/api-test/src/main/resources/idRepository/AddIdentityV2/AddIdentityV2.yml
@@ -2016,7 +2016,7 @@ AddIdentityV2:
       output: '{
    "errors": [
      {
-        "errorCode": "IDR-IDC-002"
+        "errorCode": "IDR-IDC-001"
      }
    ]
 }'

--- a/api-test/src/main/resources/idRepository/AddIdentityV2/AddIdentityV2ArrayHandle.yml
+++ b/api-test/src/main/resources/idRepository/AddIdentityV2/AddIdentityV2ArrayHandle.yml
@@ -47,6 +47,7 @@ AddIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Validate that Add Identity V2 successfully creates an identity with multiple email entries where one email is tagged as handle.
     uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandleV2_02
+    requiredHandleFields: [email]
     role: testrig
     restMethod: post
     inputTemplate: idRepository/AddIdentityV2/addIdentity_$LANGNUMBER$
@@ -91,6 +92,7 @@ AddIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Validate Add Identity V2 with multiple email entries and no email tagged as handle.
     uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandleV2_03
+    requiredHandleFields: [email]
     role: testrig
     restMethod: post
     inputTemplate: idRepository/AddIdentityV2/addIdentity_$LANGNUMBER$
@@ -179,6 +181,7 @@ AddIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Verify Add Identity V2 with multiple email entries tagged as handle.
     uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandleV2_05
+    requiredHandleFields: [email]
     role: testrig
     restMethod: post
     inputTemplate: idRepository/AddIdentityV2/addIdentity_$LANGNUMBER$
@@ -223,6 +226,7 @@ AddIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Validate Add Identity V2 with email having both handle and notification tags.
     uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandleV2_06
+    requiredHandleFields: [email]
     role: testrig
     restMethod: post
     inputTemplate: idRepository/AddIdentityV2/addIdentity_$LANGNUMBER$
@@ -311,6 +315,7 @@ AddIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Validate Add Identity V2 with selectedHandles order variation.
     uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandleV2_08
+    requiredHandleFields: [email]
     role: testrig
     restMethod: post
     inputTemplate: idRepository/AddIdentityV2/addIdentity_$LANGNUMBER$
@@ -399,6 +404,7 @@ AddIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Validate Add Identity V2 with email having only notification tag.
     uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandleV2_10
+    requiredHandleFields: [email]
     role: testrig
     restMethod: post
     inputTemplate: idRepository/AddIdentityV2/addIdentity_$LANGNUMBER$
@@ -443,6 +449,7 @@ AddIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Validate Add Identity V2 with a lengthy email array.
     uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandleV2_11
+    requiredHandleFields: [email]
     role: testrig
     restMethod: post
     inputTemplate: idRepository/AddIdentityV2/addIdentity_$LANGNUMBER$
@@ -487,6 +494,7 @@ AddIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Verify Add Identity V2 with multiple email handles from different domains.
     uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandleV2_12
+    requiredHandleFields: [email]
     role: testrig
     restMethod: post
     inputTemplate: idRepository/AddIdentityV2/addIdentity_$LANGNUMBER$
@@ -847,6 +855,7 @@ AddIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Validates that Add Identity V2 API accepts requests when duplicate selected handles are present and successfully creates the identity.
     uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandleV2_20
+    requiredHandleFields: [email]
     role: testrig
     restMethod: post
     inputTemplate: idRepository/AddIdentityV2/addIdentity_$LANGNUMBER$
@@ -891,6 +900,7 @@ AddIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Validates that Add Identity V2 API ignores case mismatches in selected handles with verifiedAttributes.
     uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandleV2_21
+    requiredHandleFields: [email]
     role: testrig
     restMethod: post
     inputTemplate: idRepository/AddIdentityV2/addIdentity_$LANGNUMBER$
@@ -935,6 +945,7 @@ AddIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Validates that Add Identity V2 API ignores selected handles with leading/trailing spaces with verifiedAttributes.
     uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandleV2_22
+    requiredHandleFields: [email]
     role: testrig
     restMethod: post
     inputTemplate: idRepository/AddIdentityV2/addIdentity_$LANGNUMBER$

--- a/api-test/src/main/resources/idRepository/RetrieveIdentityPostV2/RetrieveIdentityPostV2.yml
+++ b/api-test/src/main/resources/idRepository/RetrieveIdentityPostV2/RetrieveIdentityPostV2.yml
@@ -115,6 +115,7 @@ RetrieveIdentityPostV2:
       endPoint: /idrepository/v1/identity/idvid/v2
       description: Verify response passing email marked as handle
       uniqueIdentifier: TC_IDRepo_RetrieveIdentityPostV2_06
+      requiredHandleFields: [email]
       role: idrepo
       restMethod: post
       checkErrorsOnlyInResponse: true
@@ -135,6 +136,7 @@ RetrieveIdentityPostV2:
       endPoint: /idrepository/v1/identity/idvid/v2
       description: Verify response passing valid ID as phone number and idType as Handle
       uniqueIdentifier: TC_IDRepo_RetrieveIdentityPostV2_07
+      requiredHandleFields: [phone]
       role: idrepo
       restMethod: post
       checkErrorsOnlyInResponse: true
@@ -227,6 +229,7 @@ RetrieveIdentityPostV2:
       endPoint: /idrepository/v1/identity/idvid/v2
       description: Verify response passing valid ID making phone number as Handles
       uniqueIdentifier: TC_IDRepo_RetrieveIdentityPostV2_11
+      requiredHandleFields: [phone]
       role: idrepo
       restMethod: post
       checkErrorsOnlyInResponse: true

--- a/api-test/src/main/resources/idRepository/UpdateIdentityArrayHandle/UpdateIdentityArrayHandle.yml
+++ b/api-test/src/main/resources/idRepository/UpdateIdentityArrayHandle/UpdateIdentityArrayHandle.yml
@@ -368,6 +368,7 @@ UpdateIdentity:
       endPoint: /idrepository/v1/identity/
       description: Update Identity with one selected handle
       uniqueIdentifier: TC_IDRepo_UpdateIdentityArrayHandle_14
+      requiredHandleFields: [email]
       role: testrig
       restMethod: patch
       inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
@@ -563,7 +564,7 @@ UpdateIdentity:
 }'
   IdRepository_UpdateIdentity_withValidParams_smoke_Post_array_handle_value_withinvaliddhandle:
       endPoint: /idrepository/v1/identity/
-      description: Update Identity with invalid selected handles
+      description: Update Identity adding an unknown handle field name to selectedHandles
       uniqueIdentifier: TC_IDRepo_UpdateIdentityArrayHandle_21
       role: testrig
       restMethod: patch
@@ -591,7 +592,7 @@ UpdateIdentity:
 }'
   IdRepository_UpdateIdentity_withValidParams_smoke_Post_array_handle_value_updateselectedhandleswithinvalid:
       endPoint: /idrepository/v1/identity/
-      description: Update Identity with invalid selected handles
+      description: Update Identity replacing selectedHandles with an invalid/unknown handle name
       uniqueIdentifier: TC_IDRepo_UpdateIdentityArrayHandle_22
       role: testrig
       restMethod: patch
@@ -619,7 +620,7 @@ UpdateIdentity:
 }'
   IdRepository_UpdateIdentity_withValidParams_smoke_Post_array_handle_value_updateselectedhandleswithscehmaattrwhichisnothandle:
       endPoint: /idrepository/v1/identity/
-      description: Update Identity with scehma attribute which is not in selected handles
+      description: Update Identity adding a schema attribute that is not a handle to selectedHandles
       uniqueIdentifier: TC_IDRepo_UpdateIdentityArrayHandle_23
       role: testrig
       restMethod: patch
@@ -649,6 +650,7 @@ UpdateIdentity:
       endPoint: /idrepository/v1/identity/
       description: Update Identity with remove selected handles and update phone
       uniqueIdentifier: TC_IDRepo_UpdateIdentityArrayHandle_24
+      requiredHandleFields: [phone]
       role: testrig
       restMethod: patch
       inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
@@ -675,7 +677,7 @@ UpdateIdentity:
 }'
   IdRepository_UpdateIdentity_withValidParams_smoke_Post_array_handle_value_withupdatedhandlewhichisnotinschema:
       endPoint: /idrepository/v1/identity/
-      description: Update Identity with update selected handles which is not in schema
+      description: Update Identity setting selectedHandles to a value not present in the schema
       uniqueIdentifier: TC_IDRepo_UpdateIdentityArrayHandle_25
       role: testrig
       restMethod: patch
@@ -705,6 +707,7 @@ UpdateIdentity:
       endPoint: /idrepository/v1/identity/
       description: Update Identity selectedhandles to phone while creating it was email
       uniqueIdentifier: TC_IDRepo_UpdateIdentityArrayHandle_26
+      requiredHandleFields: [email, phone]
       role: testrig
       restMethod: patch
       inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
@@ -733,6 +736,7 @@ UpdateIdentity:
       endPoint: /idrepository/v1/identity/
       description: Update Identity selectedhandles to phone & email while creating it was only email
       uniqueIdentifier: TC_IDRepo_UpdateIdentityArrayHandle_27
+      requiredHandleFields: [email, phone]
       role: testrig
       restMethod: patch
       inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
@@ -785,11 +789,12 @@ UpdateIdentity:
       output: '{
     "status": "ACTIVATED"
 }'
-  IdRepository_UpdateIdentity_handle_value_value_all_valid_smoke_withusedphone:
+  IdRepository_UpdateIdentity_handle_value_all_valid_smoke_withusedhandlevalue:
       endPoint: /idrepository/v1/identity/
-      description: Update Identity with used phone value
+      description: Update Identity reusing the handle values of an existing identity - each schema-declared handle duplicates one already in use, so the update must be rejected
       uniqueIdentifier: TC_IDRepo_UpdateIdentityArrayHandle_29
       role: testrig
+      additionalDependencies: TC_IDRepo_AddIdentityArrayHandle_38
       restMethod: patch
       inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
       outputTemplate: idRepository/error
@@ -802,7 +807,7 @@ UpdateIdentity:
 	    "dateOfBirth": "1992/04/15",
 	    "postalCode": "14022",
 	    "email": "$EMAILVALUE$",
-	    "phone": "$ID:UpdateIdentity_withValidParams_smoke_Post_array_handle_update_smoke_sid_phone$",
+	    "phone": "$PHONENUMBERFORIDENTITY$",
 	    "referenceIdentityNumber": "6789545678878",
 	    "version": "v1",
 	    "introducerRID": "212124324784879",
@@ -821,6 +826,7 @@ UpdateIdentity:
       endPoint: /idrepository/v1/identity/
       description: Update Identity passing empty selecthandles with selected handle phone value uin
       uniqueIdentifier: TC_IDRepo_UpdateIdentityArrayHandle_30
+      requiredHandleFields: [phone]
       role: testrig
       restMethod: patch
       inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
@@ -845,11 +851,12 @@ UpdateIdentity:
       output: '{
     "status": "ACTIVATED"
 }'
-  IdRepository_UpdateIdentity_withValidParams_smoke_Post_handle_value_withphonevalue:
+  IdRepository_UpdateIdentity_withValidParams_smoke_Post_handle_value_withusedhandlevaluewithoutselectedhandles:
       endPoint: /idrepository/v1/identity/
-      description: Update Identity passing phone value without selected handle uin
+      description: Update Identity reusing another identity's handle values while omitting selectedHandles - the duplicate handle value must still be rejected (uniqueness enforced on the stored handles). NOTE - currently the server returns ACTIVATED; this test asserts the correct expected behaviour and is expected to fail until confirmed/fixed with the IdRepo team.
       uniqueIdentifier: TC_IDRepo_UpdateIdentityArrayHandle_31
       role: testrig
+      additionalDependencies: TC_IDRepo_AddIdentityArrayHandle_38
       restMethod: patch
       inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
       outputTemplate: idRepository/error
@@ -881,6 +888,7 @@ UpdateIdentity:
       endPoint: /idrepository/v1/identity/
       description: Update Identity remove selected handle then pass email value
       uniqueIdentifier: TC_IDRepo_UpdateIdentityArrayHandle_32
+      requiredHandleFields: [phone]
       role: testrig
       restMethod: patch
       inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
@@ -904,4 +912,68 @@ UpdateIdentity:
 	  }'
       output: '{
     "status": "ACTIVATED"
+}'
+  IdRepository_UpdateIdentity_withValidParams_smoke_Post_array_handle_value_withnullselectedhandles_Neg:
+      endPoint: /idrepository/v1/identity/
+      description: Update Identity passing selectedHandles as null - must be rejected
+      uniqueIdentifier: TC_IDRepo_UpdateIdentityArrayHandle_33
+      role: testrig
+      restMethod: patch
+      inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
+      outputTemplate: idRepository/error
+      input: '{
+	    "registrationId": "$RID$",
+        "id": "mosip.id.update",
+		"status": "ACTIVATED",
+	    "addressCopy": "Y",
+	    "UIN": "$ID:AddIdentity_array_handle_update_valuetags_smoke_Pos_UIN$",
+	    "dateOfBirth": "1992/04/15",
+	    "postalCode": "14022",
+	    "email": "$EMAILVALUE$",
+	    "phone": "$PHONENUMBERFORIDENTITY$",
+	    "referenceIdentityNumber": "6789545678878",
+	    "version": "v1",
+	    "introducerRID": "212124324784879",
+	    "introducerUIN": "212124324784879",
+	    "category": "individualBiometrics",
+	    "requesttime": "$TIMESTAMP$"
+	  }'
+      output: '{
+   "errors": [
+    {
+      "errorCode": "IDR-IDC-002"
+    }
+  ]
+}'
+  IdRepository_UpdateIdentity_withValidParams_smoke_Post_array_handle_value_withinvalidselectedhandletype_Neg:
+      endPoint: /idrepository/v1/identity/
+      description: Update Identity passing selectedHandles as an invalid type (string instead of array) - must be rejected
+      uniqueIdentifier: TC_IDRepo_UpdateIdentityArrayHandle_34
+      role: testrig
+      restMethod: patch
+      inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
+      outputTemplate: idRepository/error
+      input: '{
+	    "registrationId": "$RID$",
+        "id": "mosip.id.update",
+		"status": "ACTIVATED",
+	    "addressCopy": "Y",
+	    "UIN": "$ID:AddIdentity_array_handle_update_valuetags_smoke_Pos_UIN$",
+	    "dateOfBirth": "1992/04/15",
+	    "postalCode": "14022",
+	    "email": "$EMAILVALUE$",
+	    "phone": "$PHONENUMBERFORIDENTITY$",
+	    "referenceIdentityNumber": "6789545678878",
+	    "version": "v1",
+	    "introducerRID": "212124324784879",
+	    "introducerUIN": "212124324784879",
+	    "category": "individualBiometrics",
+	    "requesttime": "$TIMESTAMP$"
+	  }'
+      output: '{
+   "errors": [
+    {
+      "errorCode": "IDR-IDC-002"
+    }
+  ]
 }'

--- a/api-test/src/main/resources/idRepository/UpdateIdentityV2/UpdateIdentityV2.yml
+++ b/api-test/src/main/resources/idRepository/UpdateIdentityV2/UpdateIdentityV2.yml
@@ -1377,6 +1377,7 @@ UpdateIdentityV2:
     endPoint: /idrepository/v1/identity/v2
     description: Validate that Update Identity V2 returns error response when updating identity with a phone number which is not selected as handle.
     uniqueIdentifier: TC_IDRepo_UpdateIdentityV2_36
+    requiredHandleFields: [phone]
     role: testrig
     restMethod: patch
     inputTemplate: idRepository/UpdateIdentityV2/UpdateIdentityV2
@@ -1455,6 +1456,7 @@ UpdateIdentityV2:
     endPoint: /idrepository/v1/identity/v2
     description: Validate that Update Identity V2 returns error response when updating identity with a email which is not selected as handle.
     uniqueIdentifier: TC_IDRepo_UpdateIdentityV2_38
+    requiredHandleFields: [email]
     role: testrig
     restMethod: patch
     inputTemplate: idRepository/UpdateIdentityV2/UpdateIdentityV2

--- a/api-test/src/main/resources/idRepository/UpdateIdentityV2ArrayHandle/UpdateIdentityV2ArrayHandle.yml
+++ b/api-test/src/main/resources/idRepository/UpdateIdentityV2ArrayHandle/UpdateIdentityV2ArrayHandle.yml
@@ -46,6 +46,7 @@ UpdateIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Validates that Update Identity V2 API successfully updates an identity when multiple email values are provided but only one valid email handle is processed.
     uniqueIdentifier: TC_IDRepo_UpdateIdentityV2ArrayHandle_02
+    requiredHandleFields: [email]
     role: testrig
     restMethod: patch
     inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
@@ -89,6 +90,7 @@ UpdateIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Validates that Update Identity V2 API successfully updates an identity even when multiple email values are provided without a handle mapping.
     uniqueIdentifier: TC_IDRepo_UpdateIdentityV2ArrayHandle_03
+    requiredHandleFields: [email]
     role: testrig
     restMethod: patch
     inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
@@ -132,6 +134,7 @@ UpdateIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Validates that Update Identity V2 API successfully updates an identity when multiple email handles are provided as handle.
     uniqueIdentifier: TC_IDRepo_UpdateIdentityV2ArrayHandle_04
+    requiredHandleFields: [email]
     role: testrig
     restMethod: patch
     inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
@@ -218,6 +221,7 @@ UpdateIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Validates that Update Identity V2 API retains tagged email information with verifiedAttributes during update.
     uniqueIdentifier: TC_IDRepo_UpdateIdentityV2ArrayHandle_06
+    requiredHandleFields: [email]
     role: testrig
     restMethod: patch
     inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
@@ -261,6 +265,7 @@ UpdateIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Validates that Update Identity V2 API successfully handles and updates identities with a lengthy email array with verifiedAttributes.
     uniqueIdentifier: TC_IDRepo_UpdateIdentityV2ArrayHandle_07
+    requiredHandleFields: [email]
     role: testrig
     restMethod: patch
     inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
@@ -304,6 +309,7 @@ UpdateIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Validates that Update Identity V2 API successfully updates an identity when multiple email handles with different domains are provided.
     uniqueIdentifier: TC_IDRepo_UpdateIdentityV2ArrayHandle_08
+    requiredHandleFields: [email]
     role: testrig
     restMethod: patch
     inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
@@ -347,6 +353,7 @@ UpdateIdentityV2ArrayHandle:
     endPoint: /idrepository/v1/identity/v2
     description: Validates that Update Identity V2 API successfully updates an identity without modifying handle parameters.
     uniqueIdentifier: TC_IDRepo_UpdateIdentityV2ArrayHandle_09
+    requiredHandleFields: [email]
     role: testrig
     restMethod: patch
     inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle


### PR DESCRIPTION
Updated the request body of the Add Identity to consider full schema
- Updated the automatic ignoring of few handle scenarios if the field is not considered as handles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Add and Update Identity handling for schema-defined and array-based handles.
  * Added validation for missing, invalid, duplicate, and non-schema handle values.
  * Improved support for selected-handle updates and handle value reuse.
  * Corrected expected validation responses for missing email scenarios.

* **Tests**
  * Expanded coverage for required handles, invalid selections, unsupported fields, and malformed handle values.
  * Added schema-aware test conditions for Add Identity, Update Identity, and Retrieve Identity flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->