### PR TITLE
MOSIP-45415 - Removed the exposed secrets from the repo

### DIFF
--- a/api-test/src/main/resources/config/Idrepo.properties
+++ b/api-test/src/main/resources/config/Idrepo.properties
@@ -3,45 +3,42 @@
 #------------------------ Environment URLs and Database Connections ------------------------#
 
 # Keycloak URL.
-keycloak-external-url = https://iam.dev11.mosip.net
+keycloak-external-url = https://iam.dev-int.mosip.net
 
 # PostgreSQL URLs for audit and partner databases.
-audit_url = jdbc:postgresql://dev11.mosip.net:5433/mosip_audit
-partner_url = jdbc:postgresql://dev11.mosip.net:5433/mosip_ida
+audit_url = jdbc:postgresql://dev-int.mosip.net:5432/mosip_audit
+partner_url = jdbc:postgresql://dev-int.mosip.net:5432/mosip_ida
 
 # Database server for connections.
-db-server = api-internal.dev11.mosip.net
-db-port=5433
+db-server = dev-int.mosip.net
+db-port=5432
 
 
-
-
-
-#------------------------ secrets and passwords  ------------------------#
+#------------------------ secrets and passwords  ------------------------#
 
 #------------------------ Keycloak Passwords ------------------------#
 # Used for Keycloak authentication.
-keycloak_Password = mGUWDoYde0
+keycloak_Password =
 
 #------------------------ PostgreSQL Database Passwords ------------------------#
 # Credentials for connecting to Postgres databases.
 audit_password =
 partner_password =
-postgres-password = 53AV^o#6%s!DOot9
+postgres-password =
 
 #-------- Client Secret Keys ----------#
 # These keys are used for various services, make sure to update the values as required when running locally.
 
 mosip_partner_client_secret =
-mosip_pms_client_secret = v7feDaGvLgIwfj1S
-mosip_resident_client_secret = essFo4b7sBRFDUil
-mosip_idrepo_client_secret = V2xQ5VVPuzoqz121
-mosip_reg_client_secret = BUTmhCMBCDzLymMw
-mosip_admin_client_secret = JejzM8NC5zhUkcND
-mosip_hotlist_client_secret = 26TMigT0zS90hDKJ
-mosip_regproc_client_secret = kbXCEnB2TFFrsKlY
-mpartner_default_mobile_secret = LY46hFKuEbuUbZLd
-mosip_testrig_client_secret = v635vUo7doHxB9j2
+mosip_pms_client_secret =
+mosip_resident_client_secret =
+mosip_idrepo_client_secret =
+mosip_reg_client_secret =
+mosip_admin_client_secret =
+mosip_hotlist_client_secret =
+mosip_regproc_client_secret =
+mpartner_default_mobile_secret =
+mosip_testrig_client_secret =
 AuthClientSecret =
 mosip_crvs1_client_secret =
 


### PR DESCRIPTION
MOSIP-45415 - Removed the exposed secrets from the repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated service endpoints to the dev-int environment.
  * Changed the database connection port to 5432.
  * Cleared previously populated authentication, database, and client secret values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->