### PR TITLE
MOSIP-45383 - Added the testcases of Array of handles

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoArrayHandle.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoArrayHandle.java
@@ -120,9 +120,7 @@ public class IdRepoArrayHandle {
 			applySavedHandleValues(identity);
 			return jsonObj.toString();
 		}
-		// Replays only the previously saved email value (not other saved handles) onto a brand-new
-		// identity, so a still-active handle on another field (e.g. phone) on the original identity
-		// cannot cause an unrelated IDR-IDC-014 collision here.
+		// Replays only the saved email value, avoiding a false IDR-IDC-014 collision from other active handles.
 		if (testCaseName.contains("_withReusableEmailAfterRemoval")) {
 			applySavedEmailValueOnly(identity);
 			return jsonObj.toString();
@@ -163,8 +161,7 @@ public class IdRepoArrayHandle {
 			applyDeleteHandleFromRecord(identity);
 			return jsonObj.toString();
 		}
-		// Removes only the email handle (value + selectedHandles entry), leaving any other handle
-		// (e.g. phone) untouched, so a later identity can safely reuse just the freed email value.
+		// Removes only the email handle, leaving other handles untouched, so its value can be reused later.
 		if (testCaseName.contains("_removeSavedEmailHandle")) {
 			removeHandleFromIdentity(identity, emailFieldName);
 			return jsonObj.toString();
@@ -532,14 +529,17 @@ public class IdRepoArrayHandle {
 		}
 	}
 
-	/** Replays only the saved email value onto this identity - used to prove a handle value becomes
-	 * reusable once its original holder's association with it (and only it) is removed. */
+	/** Replays only the saved email value onto this identity, to prove a freed handle value is reusable. */
 	private static void applySavedEmailValueOnly(JSONObject identity) {
 		String emailField = resolveEmailFieldName();
 		String savedEmail = savedHandleValues.get(emailField);
-		if (savedEmail != null && identity.has(emailField)) {
-			writeHandleValue(identity, emailField, savedEmail);
+		if (savedEmail == null) {
+			throw new IllegalStateException("No saved email handle value is available for reuse");
 		}
+		if (!identity.has(emailField)) {
+			throw new IllegalStateException("Email handle field is absent from the identity");
+		}
+		writeHandleValue(identity, emailField, savedEmail);
 	}
 
 	private static String resolveEmailFieldName() {
@@ -557,9 +557,7 @@ public class IdRepoArrayHandle {
 		}
 	}
 
-	/** Appends two more untagged, validator-satisfying values to an existing array-typed handle
-	 * (field-agnostic — targets whichever handle IdRepoUtil.resolveHandleOfType("array") resolves to).
-	 * Used to prove that handle status is driven by selectedHandles membership, not per-item tags. */
+	/** Appends two more untagged values to an existing array-typed handle, to prove tags don't gate status. */
 	private static void applyAppendUntaggedValues(JSONArray handleArray, String handle) {
 		JSONObject second = new JSONObject();
 		second.put("value", IdRepoUtil.generateSchemaFieldValue(handle));

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoArrayHandle.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoArrayHandle.java
@@ -120,6 +120,13 @@ public class IdRepoArrayHandle {
 			applySavedHandleValues(identity);
 			return jsonObj.toString();
 		}
+		// Replays only the previously saved email value (not other saved handles) onto a brand-new
+		// identity, so a still-active handle on another field (e.g. phone) on the original identity
+		// cannot cause an unrelated IDR-IDC-014 collision here.
+		if (testCaseName.contains("_withReusableEmailAfterRemoval")) {
+			applySavedEmailValueOnly(identity);
+			return jsonObj.toString();
+		}
 
 		JSONArray selectedHandles = identity.getJSONArray("selectedHandles");
 		for (int i = 0; i < selectedHandles.length(); i++) {
@@ -154,6 +161,12 @@ public class IdRepoArrayHandle {
 		// More-specific patterns checked before substrings they contain.
 		if (testCaseName.contains("_withdeletehandlefromrecord")) {
 			applyDeleteHandleFromRecord(identity);
+			return jsonObj.toString();
+		}
+		// Removes only the email handle (value + selectedHandles entry), leaving any other handle
+		// (e.g. phone) untouched, so a later identity can safely reuse just the freed email value.
+		if (testCaseName.contains("_removeSavedEmailHandle")) {
+			removeHandleFromIdentity(identity, emailFieldName);
 			return jsonObj.toString();
 		}
 		if (testCaseName.contains("_withemptyhandles")) {
@@ -337,6 +350,9 @@ public class IdRepoArrayHandle {
 			applyWithUpdateValues(handleArray, handle, resolveEmailFieldName());
 		} else if (testCaseName.contains("_withmultiplevalues")) {
 			putMultipleValues(handleArray);
+		} else if (testCaseName.contains("_appendUntaggedValuesToArrayHandle")
+				&& handle.equals(IdRepoUtil.resolveHandleOfType("array"))) {
+			applyAppendUntaggedValues(handleArray, handle);
 		} else if (testCaseName.contains("_withupdatetagsandhandles")) {
 			applyWithUpdateTagsAndHandles(handleArray);
 		} else if (testCaseName.contains("_withupdatetags")) {
@@ -516,6 +532,16 @@ public class IdRepoArrayHandle {
 		}
 	}
 
+	/** Replays only the saved email value onto this identity - used to prove a handle value becomes
+	 * reusable once its original holder's association with it (and only it) is removed. */
+	private static void applySavedEmailValueOnly(JSONObject identity) {
+		String emailField = resolveEmailFieldName();
+		String savedEmail = savedHandleValues.get(emailField);
+		if (savedEmail != null && identity.has(emailField)) {
+			writeHandleValue(identity, emailField, savedEmail);
+		}
+	}
+
 	private static String resolveEmailFieldName() {
 		String email = AdminTestUtil.getValueFromAuthActuator("json-property", "emailId");
 		return email.replaceAll("\\[\"|\"]", "");
@@ -529,6 +555,18 @@ public class IdRepoArrayHandle {
 		for (int j = 0; j < handleArray.length(); j++) {
 			handleArray.getJSONObject(j).put("values", valuesArray);
 		}
+	}
+
+	/** Appends two more untagged, validator-satisfying values to an existing array-typed handle
+	 * (field-agnostic — targets whichever handle IdRepoUtil.resolveHandleOfType("array") resolves to).
+	 * Used to prove that handle status is driven by selectedHandles membership, not per-item tags. */
+	private static void applyAppendUntaggedValues(JSONArray handleArray, String handle) {
+		JSONObject second = new JSONObject();
+		second.put("value", IdRepoUtil.generateSchemaFieldValue(handle));
+		JSONObject third = new JSONObject();
+		third.put("value", IdRepoUtil.generateSchemaFieldValue(handle));
+		handleArray.put(second);
+		handleArray.put(third);
 	}
 
 	// ===== AddIdentity Private Handlers =====

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoUtil.java
@@ -90,6 +90,10 @@ public class IdRepoUtil extends AdminTestUtil {
 			throw new SkipException(
 					"No array-typed handle in the current IdSchema — " + GlobalConstants.FEATURE_NOT_SUPPORTED_MESSAGE);
 		}
+		if (testCaseName.contains("_appendUntaggedValuesToArrayHandle") && !schemaHasHandleOfType("array")) {
+			throw new SkipException(
+					"No array-typed handle in the current IdSchema — " + GlobalConstants.FEATURE_NOT_SUPPORTED_MESSAGE);
+		}
 		if (testCaseName.contains("_extraNonSchemaField") && schemaAllowsAdditionalProperties()) {
 			throw new SkipException("Schema permits additional properties, unknown-field rejection not applicable — "
 					+ GlobalConstants.FEATURE_NOT_SUPPORTED_MESSAGE);

--- a/api-test/src/main/resources/idRepository/AddIdentity/AddIdentityArrayHandlePostUpdate.yml
+++ b/api-test/src/main/resources/idRepository/AddIdentity/AddIdentityArrayHandlePostUpdate.yml
@@ -1,0 +1,37 @@
+AddIdentity:
+   IdRepository_AddIdentity_withReusableEmailAfterRemoval:
+      endPoint: /idrepository/v1/identity/
+      description: After user1's email handle was removed via update (TC_IDRepo_UpdateIdentityArrayHandle_36), a new identity maps the same freed email value as a handle - must be accepted, not rejected as a duplicate
+      uniqueIdentifier: TC_IDRepo_AddIdentityArrayHandlePostUpdate_01
+      requiredHandleFields: [email]
+      additionalDependencies: TC_IDRepo_UpdateIdentityArrayHandle_36
+      role: testrig
+      restMethod: post
+      inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
+      outputTemplate: idRepository/AddIdentity/addIdentityResult
+      input: '{
+  "value": "$BIOVALUE$",
+  "id": "mosip.id.create",
+  "registrationId": "$RID$",
+  "addressCopy": "Y",
+  "biometricReferenceId": "23452353",
+
+   "UIN": "$UIN$",
+
+  "dateOfBirth": "1992/04/15",
+
+  "postalCode": "14022",
+  "email": "$EMAILVALUE$",
+  "phone": "$PHONENUMBERFORIDENTITY$",
+  "referenceIdentityNumber": "6789545678878",
+  "version": "v1",
+
+   "introducerRID": "212124324784879",
+   "introducerUIN": "212124324784879",
+
+   "category": "individualBiometrics",
+   "requesttime": "$TIMESTAMP$"
+}'
+      output: '{
+  "status":"ACTIVATED"
+}'

--- a/api-test/src/main/resources/idRepository/AddIdentity/AddIdentityForBlockedHandleCheck.yml
+++ b/api-test/src/main/resources/idRepository/AddIdentity/AddIdentityForBlockedHandleCheck.yml
@@ -1,7 +1,7 @@
 AddIdentity:
    IdRepository_AddIdentity_forBlockedHandleCheck_smoke_Pos:
       endPoint: /idrepository/v1/identity/
-      description: Dedicated throwaway identity (with email as a selected handle) used only to verify that blocking the UIN cascades a DELETE_REQUESTED status onto its handle(s) in idrepo.handle
+      description: Throwaway identity (email as a selected handle), used solely as setup for the BLOCKED status update in UpdateIdentityBlockedHandleCheck
       uniqueIdentifier: TC_IDRepo_AddIdentityForBlockedHandleCheck_01
       requiredHandleFields: [email]
       role: testrig

--- a/api-test/src/main/resources/idRepository/AddIdentity/AddIdentityForBlockedHandleCheck.yml
+++ b/api-test/src/main/resources/idRepository/AddIdentity/AddIdentityForBlockedHandleCheck.yml
@@ -1,0 +1,31 @@
+AddIdentity:
+   IdRepository_AddIdentity_forBlockedHandleCheck_smoke_Pos:
+      endPoint: /idrepository/v1/identity/
+      description: Dedicated throwaway identity (with email as a selected handle) used only to verify that blocking the UIN cascades a DELETE_REQUESTED status onto its handle(s) in idrepo.handle
+      uniqueIdentifier: TC_IDRepo_AddIdentityForBlockedHandleCheck_01
+      requiredHandleFields: [email]
+      role: testrig
+      restMethod: post
+      inputTemplate: idRepository/AddIdentity/addIdentity_$LANGNUMBER$
+      outputTemplate: idRepository/AddIdentity/addIdentityResult
+      input: '{
+  "value": "$BIOVALUE$",
+  "id": "mosip.id.create",
+  "registrationId": "$RID$",
+  "addressCopy": "Y",
+  "biometricReferenceId": "23452353",
+   "UIN": "$UIN$",
+  "dateOfBirth": "1992/04/15",
+  "postalCode": "14022",
+  "email": "$EMAILVALUE$",
+  "phone": "$PHONENUMBERFORIDENTITY$",
+  "referenceIdentityNumber": "6789545678878",
+  "version": "v1",
+   "introducerRID": "212124324784879",
+   "introducerUIN": "212124324784879",
+   "category": "individualBiometrics",
+   "requesttime": "$TIMESTAMP$"
+}'
+      output: '{
+  "status":"ACTIVATED"
+}'

--- a/api-test/src/main/resources/idRepository/UpdateIdentity/UpdateIdentityBlockedHandleCheck.yml
+++ b/api-test/src/main/resources/idRepository/UpdateIdentity/UpdateIdentityBlockedHandleCheck.yml
@@ -1,0 +1,22 @@
+UpdateIdentity:
+  IdRepository_UpdateIdentity_BLOCKED_forHandleCheck_smoke_Pos:
+      endPoint: /idrepository/v1/identity/
+      description: Block the throwaway identity from AddIdentityForBlockedHandleCheck.yml. Confirms the Update Identity API accepts status=BLOCKED (a valid value per mosip.idrepo.identity.uin-status) and echoes it back. Per CredentialServiceManager.sendUINEventToIDA this should also cascade all of this UIN's handles to DELETE_REQUESTED in idrepo.handle, but that downstream effect is NOT asserted here - a DB-level check for it was deliberately removed as an unreliable weak signal on a shared live environment (see git history). Intentionally not reverted back to ACTIVATED - this identity is throwaway and BLOCKED is not expected to be a reversible transition.
+      uniqueIdentifier: TC_IDRepo_UpdateIdentityBlockedHandleCheck_01
+      requiredHandleFields: [email]
+      additionalDependencies: TC_IDRepo_AddIdentityForBlockedHandleCheck_01
+      role: testrig
+      restMethod: patch
+      inputTemplate: idRepository/UpdateIdentity/updateIdentity
+      outputTemplate: idRepository/UpdateIdentity/updateIdentityResult
+      input: '{
+      "registrationId":"$RID$",
+      "UIN":"$ID:AddIdentity_forBlockedHandleCheck_smoke_Pos_UIN$",
+      "status": "BLOCKED",
+      "dateOfBirth": "1992/04/15",
+      "requesttime": "$TIMESTAMP$",
+      "version": "v1"
+      }'
+      output: '{
+    "status": "BLOCKED"
+}'

--- a/api-test/src/main/resources/idRepository/UpdateIdentity/UpdateIdentityBlockedHandleCheck.yml
+++ b/api-test/src/main/resources/idRepository/UpdateIdentity/UpdateIdentityBlockedHandleCheck.yml
@@ -1,7 +1,7 @@
 UpdateIdentity:
   IdRepository_UpdateIdentity_BLOCKED_forHandleCheck_smoke_Pos:
       endPoint: /idrepository/v1/identity/
-      description: Block the throwaway identity from AddIdentityForBlockedHandleCheck.yml. Confirms the Update Identity API accepts status=BLOCKED (a valid value per mosip.idrepo.identity.uin-status) and echoes it back. Per CredentialServiceManager.sendUINEventToIDA this should also cascade all of this UIN's handles to DELETE_REQUESTED in idrepo.handle, but that downstream effect is NOT asserted here - a DB-level check for it was deliberately removed as an unreliable weak signal on a shared live environment (see git history). Intentionally not reverted back to ACTIVATED - this identity is throwaway and BLOCKED is not expected to be a reversible transition.
+      description: Blocks the throwaway identity; confirms status=BLOCKED is accepted and echoed back.
       uniqueIdentifier: TC_IDRepo_UpdateIdentityBlockedHandleCheck_01
       requiredHandleFields: [email]
       additionalDependencies: TC_IDRepo_AddIdentityForBlockedHandleCheck_01

--- a/api-test/src/main/resources/idRepository/UpdateIdentityArrayHandle/UpdateIdentityArrayHandle.yml
+++ b/api-test/src/main/resources/idRepository/UpdateIdentityArrayHandle/UpdateIdentityArrayHandle.yml
@@ -973,3 +973,61 @@ UpdateIdentity:
     }
   ]
 }'
+  IdRepository_UpdateIdentity_withValidParams_smoke_Post_appendUntaggedValuesToArrayHandle:
+      endPoint: /idrepository/v1/identity/
+      description: Base identity has one untagged value in its array-typed handle (selected at registration); update appends two more untagged values to the same handle - all three values must be accepted as handles
+      uniqueIdentifier: TC_IDRepo_UpdateIdentityArrayHandle_35
+      role: testrig
+      restMethod: patch
+      inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
+      outputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandleResult
+      input: '{
+	    "registrationId": "$RID$",
+        "id": "mosip.id.update",
+		"status": "ACTIVATED",
+	    "addressCopy": "Y",
+	    "UIN": "$ID:AddIdentity_array_handle_value_withouttags_UIN$",
+	    "dateOfBirth": "1992/04/15",
+	    "postalCode": "14022",
+	    "email": "$EMAILVALUE$",
+	    "phone": "$PHONENUMBERFORIDENTITY$",
+	    "referenceIdentityNumber": "6789545678878",
+	    "version": "v1",
+	    "introducerRID": "212124324784879",
+	    "introducerUIN": "212124324784879",
+	    "category": "individualBiometrics",
+	    "requesttime": "$TIMESTAMP$"
+	  }'
+      output: '{
+    "status": "ACTIVATED"
+}'
+  IdRepository_UpdateIdentity_savedHandleValue_removeSavedEmailHandle:
+      endPoint: /idrepository/v1/identity/
+      description: Remove only the email handle from user1 (value + selectedHandles entry), leaving any other handle untouched, so the freed email value can later be reused by a different identity
+      uniqueIdentifier: TC_IDRepo_UpdateIdentityArrayHandle_36
+      requiredHandleFields: [email]
+      additionalDependencies: TC_IDRepo_AddIdentityArrayHandle_38
+      role: testrig
+      restMethod: patch
+      inputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandle
+      outputTemplate: idRepository/UpdateIdentityArrayHandle/updateIdentityArrayHandleResult
+      input: '{
+	    "registrationId": "$RID$",
+        "id": "mosip.id.update",
+		"status": "ACTIVATED",
+	    "addressCopy": "Y",
+	    "UIN": "$ID:AddIdentity_array_handle_value_smoke_Pos_save_withdublicatevalue_UIN$",
+	    "dateOfBirth": "1992/04/15",
+	    "postalCode": "14022",
+	    "email": "$EMAILVALUE$",
+	    "phone": "$PHONENUMBERFORIDENTITY$",
+	    "referenceIdentityNumber": "6789545678878",
+	    "version": "v1",
+	    "introducerRID": "212124324784879",
+	    "introducerUIN": "212124324784879",
+	    "category": "individualBiometrics",
+	    "requesttime": "$TIMESTAMP$"
+	  }'
+      output: '{
+    "status": "ACTIVATED"
+}'

--- a/api-test/testNgXmlFiles/IdrepositorySuite.xml
+++ b/api-test/testNgXmlFiles/IdrepositorySuite.xml
@@ -65,6 +65,16 @@
 		</classes>
 	</test>
 
+	<!-- Runs after UpdateIdentityArrayHandle: reuses an email value freed by
+	     TC_IDRepo_UpdateIdentityArrayHandle_36 in a brand-new Add Identity call. -->
+	<test name="AddIdentityArrayHandlePostUpdate">
+		<parameter name="ymlFile"
+			value="idRepository/AddIdentity/AddIdentityArrayHandlePostUpdate.yml" />
+		<classes>
+			<class name="io.mosip.testrig.apirig.idrepo.testscripts.AddIdentity" />
+		</classes>
+	</test>
+
 	<test name="UpdateIdentity">
 		<parameter name="ymlFile"
 			value="idRepository/UpdateIdentity/UpdateIdentity.yml" />

--- a/api-test/testNgXmlFiles/IdrepositorySuite.xml
+++ b/api-test/testNgXmlFiles/IdrepositorySuite.xml
@@ -65,7 +65,7 @@
 		</classes>
 	</test>
 
-	<!-- Runs after UpdateIdentityArrayHandle: reuses an email value freed by TC_IDRepo_UpdateIdentityArrayHandle_36 in a brand-new Add Identity call. -->
+	<!-- Reuses the email freed by TC_IDRepo_UpdateIdentityArrayHandle_36 in a new Add Identity call. -->
 	<test name="AddIdentityArrayHandlePostUpdate">
 		<parameter name="ymlFile"
 			value="idRepository/AddIdentity/AddIdentityArrayHandlePostUpdate.yml" />
@@ -281,7 +281,7 @@
 		</classes>
 	</test>
 
-	<!-- BLOCKED is a one-way UIN status transition (not reverted like DEACTIVATED/ACTIVATED elsewhere in this suite), so this whole flow runs last, against its own dedicated throwaway identity, so it can't affect any earlier test's assumptions. -->
+	<!-- BLOCKED is a one-way transition; runs last against its own throwaway identity to avoid affecting earlier tests. -->
 	<test name="AddIdentityForBlockedHandleCheck">
 		<parameter name="ymlFile"
 			value="idRepository/AddIdentity/AddIdentityForBlockedHandleCheck.yml" />

--- a/api-test/testNgXmlFiles/IdrepositorySuite.xml
+++ b/api-test/testNgXmlFiles/IdrepositorySuite.xml
@@ -65,8 +65,7 @@
 		</classes>
 	</test>
 
-	<!-- Runs after UpdateIdentityArrayHandle: reuses an email value freed by
-	     TC_IDRepo_UpdateIdentityArrayHandle_36 in a brand-new Add Identity call. -->
+	<!-- Runs after UpdateIdentityArrayHandle: reuses an email value freed by TC_IDRepo_UpdateIdentityArrayHandle_36 in a brand-new Add Identity call. -->
 	<test name="AddIdentityArrayHandlePostUpdate">
 		<parameter name="ymlFile"
 			value="idRepository/AddIdentity/AddIdentityArrayHandlePostUpdate.yml" />
@@ -279,6 +278,24 @@
 			value="idRepository/AuthInternalUnlock/AuthInternalUnlock.yml" />
 		<classes>
 			<class name="io.mosip.testrig.apirig.idrepo.testscripts.SimplePost" />
+		</classes>
+	</test>
+
+	<!-- BLOCKED is a one-way UIN status transition (not reverted like DEACTIVATED/ACTIVATED elsewhere in this suite), so this whole flow runs last, against its own dedicated throwaway identity, so it can't affect any earlier test's assumptions. -->
+	<test name="AddIdentityForBlockedHandleCheck">
+		<parameter name="ymlFile"
+			value="idRepository/AddIdentity/AddIdentityForBlockedHandleCheck.yml" />
+		<classes>
+			<class name="io.mosip.testrig.apirig.idrepo.testscripts.AddIdentity" />
+		</classes>
+	</test>
+
+	<test name="UpdateIdentityBlockedHandleCheck">
+		<parameter name="ymlFile"
+			value="idRepository/UpdateIdentity/UpdateIdentityBlockedHandleCheck.yml" />
+		<classes>
+			<class
+				name="io.mosip.testrig.apirig.idrepo.testscripts.UpdateIdentity" />
 		</classes>
 	</test>
 


### PR DESCRIPTION
MOSIP-45383 - Added the testcases of Array of handles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reusing email handles after they are removed from an identity.
  * Added support for appending untagged values to array-based identity handles.
  * Added support for removing saved email handles while preserving other identity data.
  * Added identity creation and update flows for blocked-handle scenarios.

* **Tests**
  * Expanded API coverage for email reuse, blocked handles, array updates, and handle removal.
  * Tests now skip array-handle scenarios when the configured schema does not support them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->