### PR TITLE
MOSIP-45405: Auto-select Idrepo-local.properties for localhost runs

### DIFF
--- a/api-test/.gitignore
+++ b/api-test/.gitignore
@@ -34,6 +34,8 @@ test.txt
 src/logs/mosip-api-test.log
 /target/
 target/
+.env.local
+.env.qa11new
 test-output/
 testng-report/
 /reg

--- a/api-test/README.md
+++ b/api-test/README.md
@@ -73,26 +73,15 @@ Do **not** commit local secrets or localhost URLs in `Idrepo.properties`.
 
 ## Run against localhost
 
-Use this when ID Repository is running on your machine (service on port `8090`, typically with a local gateway on `8082`).
+Use this when ID Repository is running on your machine (service on port `8090`, typically with a local gateway / WireMock on `8082`).
 
-### 1. Point `Idrepo.properties` at localhost
+### 1. Config file auto-select
 
-Edit `api-test/src/main/resources/config/Idrepo.properties` locally (do not push these values):
+When `-Denv.endpoint` contains `localhost` or `127.0.0.1`, the runner loads `config/Idrepo-local.properties` automatically. Otherwise it loads `config/Idrepo.properties`. Optional override: `-Didrepo.propertiesFile=<name>`.
 
-```properties
-keycloak-external-url = http://localhost:8082
-audit_url = jdbc:postgresql://localhost:5455/mosip_idrepo
-partner_url = jdbc:postgresql://localhost:5455/mosip_idrepo
-db-server = localhost
-db-port = 5455
-postgres-password = <local postgres password>
-authCertsPath = target/local-authcerts
-mosip_components_base_urls = idrepository=localhost:8082;authmanager=localhost:8082;masterdata=localhost:8082;idgenerator=localhost:8082;keymanager=localhost:8082;auditmanager=localhost:8082;datashare=localhost:8082;partnermanager=localhost:8082;policymanager=localhost:8082;credentialservice=localhost:8082;credentialrequest=localhost:8082
-```
+`Idrepo-local.properties` already points at local Keycloak/WireMock (`:8082`), Postgres (`:5455`), and component base URLs (`idrepository` on `:8090`, stubs on `:8082`). Leave secrets blank in the file and supply them via `.env.local` / environment variables (`ConfigManager` prefers `System.getenv(key)`).
 
-Fill client secrets and `keycloak_Password` for your local IAM. `ConfigManager` also reads matching environment variables, so you can leave secrets blank in the file and export them in the shell instead.
-
-When `env.endpoint` is `localhost` or `127.0.0.1`, the runner skips Keycloak admin user setup and partner/device cert generation, and it sanitizes Windows cert folder names that contain `:`.
+When `env.endpoint` is `localhost` or `127.0.0.1`, the runner also skips Keycloak admin user setup and partner/device cert generation, and it sanitizes Windows cert folder names that contain `:`.
 
 ### 2. Build and run
 

--- a/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoConfigManager.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/idrepo/utils/IdRepoConfigManager.java
@@ -12,27 +12,60 @@ import io.mosip.testrig.apirig.utils.ConfigManager;
 
 public class IdRepoConfigManager extends ConfigManager{
 	private static final Logger LOGGER = Logger.getLogger(IdRepoConfigManager.class);
-	
+
+	private static final String LOCAL_PROPERTIES = "Idrepo-local.properties";
+	private static final String ENV_PROPERTIES = "Idrepo.properties";
+
 	public static void init() {
 		Logger configManagerLogger = Logger.getLogger(ConfigManager.class);
 		configManagerLogger.setLevel(Level.WARN);
 		
 		Map<String, Object> moduleSpecificPropertiesMap = new HashMap<>();
-		// Load scope specific properties
+		// Auto-select: localhost / 127.0.0.1 in -Denv.endpoint → Idrepo-local.properties,
+		// otherwise Idrepo.properties. Optional override: -Didrepo.propertiesFile=<name>.
+		// Env vars still win via ConfigManager.
 		try {
-			String path = MosipTestRunner.getGlobalResourcePath() + "/config/Idrepo.properties";
+			String propertiesFile = resolvePropertiesFile();
+			String path = MosipTestRunner.getGlobalResourcePath() + "/config/" + propertiesFile;
+			LOGGER.info("Loading idrepo config from: " + path);
 			Properties props = getproperties(path);
-			// Convert Properties to Map and add to moduleSpecificPropertiesMap
 			for (String key : props.stringPropertyNames()) {
 				moduleSpecificPropertiesMap.put(key, props.getProperty(key));
 			}
 		} catch (Exception e) {
 			LOGGER.error(e.getMessage());
 		}
-		// Add module specific properties as well.
 		init(moduleSpecificPropertiesMap);
 	}
 
-	
-	 
+	/**
+	 * Resolves which properties file to load.
+	 * <ul>
+	 *   <li>Explicit {@code -Didrepo.propertiesFile=...} wins if set</li>
+	 *   <li>Else if {@code -Denv.endpoint} contains localhost / 127.0.0.1 → {@code Idrepo-local.properties}</li>
+	 *   <li>Else → {@code Idrepo.properties} (remote env)</li>
+	 * </ul>
+	 */
+	static String resolvePropertiesFile() {
+		String override = System.getProperty("idrepo.propertiesFile");
+		if (override != null && !override.isBlank()) {
+			LOGGER.info("Using explicit idrepo.propertiesFile=" + override);
+			return override.trim();
+		}
+		if (isLocalEndpoint()) {
+			LOGGER.info("env.endpoint is localhost → loading " + LOCAL_PROPERTIES);
+			return LOCAL_PROPERTIES;
+		}
+		LOGGER.info("env.endpoint is remote → loading " + ENV_PROPERTIES);
+		return ENV_PROPERTIES;
+	}
+
+	static boolean isLocalEndpoint() {
+		String endpoint = System.getProperty("env.endpoint", "");
+		if (endpoint == null || endpoint.isBlank()) {
+			return false;
+		}
+		String lower = endpoint.toLowerCase();
+		return lower.contains("localhost") || lower.contains("127.0.0.1");
+	}
 }

--- a/api-test/src/main/resources/config/Idrepo-local.properties
+++ b/api-test/src/main/resources/config/Idrepo-local.properties
@@ -1,0 +1,69 @@
+#---------------------------------- Local docker-compose (does NOT replace Idrepo.properties) ----------#
+# Auto-selected when -Denv.endpoint contains localhost or 127.0.0.1
+# (override: -Didrepo.propertiesFile=Idrepo-local.properties).
+# Stack: id-repository/local-dev-setup
+#   - Host id-repository-service on :8090 (run-idrepo-local.bat / .sh)
+#   - WireMock local IAM + stubs on :8082
+#   - Keymanager on :8088
+# Remote / QA runs use Idrepo.properties (env.endpoint is not localhost).
+#
+# Secrets: leave blank here. Supply via .env.local or environment variables.
+# ConfigManager reads System.getenv(key) over file values.
+
+#------------------------ Environment URLs and Database Connections ------------------------#
+
+# Local IAM is WireMock (no Keycloak container). Issuer/JWKS/token live on :8082.
+keycloak-external-url = http://localhost:8082
+
+# Local Postgres (compose maps 5455 → 5432). Missing schemas (ida/master/pms/audit) are skipped by DBManager.
+audit_url = jdbc:postgresql://localhost:5455/mosip_idrepo
+partner_url = jdbc:postgresql://localhost:5455/mosip_idrepo
+db-server = localhost
+db-port = 5455
+db-su-user = postgres
+postgres-password =
+km_db_schema = keymgr
+
+#------------------------ Keycloak Passwords ------------------------#
+# Unused by local IAM; kept so ConfigManager has a non-null value if read.
+keycloak_Password =
+
+#------------------------ Client secrets (set via env / .env.local) ------------------------#
+mosip_partner_client_secret =
+mosip_pms_client_secret =
+mosip_resident_client_secret =
+mosip_idrepo_client_secret =
+mosip_reg_client_secret =
+mosip_admin_client_secret =
+mosip_hotlist_client_secret =
+mosip_regproc_client_secret =
+mpartner_default_mobile_secret =
+mosip_testrig_client_secret =
+AuthClientSecret =
+mosip_crvs1_client_secret =
+
+#------------------------ Generic Configuration ------------------------#
+# no = same as the fat-jar / bat path. yes dumps full CBEFF into the IDE console and is very slow.
+enableDebug = no
+mockNotificationChannel = email,phone
+push-reports-to-s3 = no
+mountPathForReport = target/local-reports
+authCertsPath = target/local-authcerts
+xssProtectionCheck = no
+eSignetDeployed = no
+
+# Modules not present in local compose — skip related cases where the framework checks this list.
+servicesNotDeployed = resident,esignet,regproc,prereg,hotlist,ida,partner,mimoto,rid_generator
+
+# Host JVM under test on :8090; WireMock on :8082 for IAM / masterdata / idgenerator / PMS / datashare.
+mosip_components_base_urls = idrepository=localhost:8090;credentialservice=localhost:8090;credentialrequest=localhost:8090;keymanager=localhost:8088;authmanager=localhost:8082;masterdata=localhost:8082;idgenerator=localhost:8082;auditmanager=localhost:8082;datashare=localhost:8082;partnermanager=localhost:8082;policymanager=localhost:8082
+
+moduleNamePattern =
+# UniqueIdentifier filter (comma-separated). Empty = whole suite.
+testCasesToExecute =
+
+# Local stack is fast; shorten idrepo post-UIN wait used by some scripts.
+Delaytime = 5000
+uinGenerationProcessingDelayTimeInMilliSeconds = 5000
+uinGenDelayTime = 2000
+uinGenMaxLoopCount = 10

--- a/api-test/src/main/resources/config/Idrepo.properties
+++ b/api-test/src/main/resources/config/Idrepo.properties
@@ -1,4 +1,8 @@
 #---------------------------------- Modifiable Properties ----------------------------------------------------------#
+# Remote / QA env runs: auto-selected when -Denv.endpoint is NOT localhost.
+# Local runs: auto-load Idrepo-local.properties instead.
+# Optional override: -Didrepo.propertiesFile=<name>
+# Secrets: leave blank; supply via env vars / .env.* (ConfigManager prefers System.getenv).
 
 #------------------------ Environment URLs and Database Connections ------------------------#
 


### PR DESCRIPTION
## Summary
- Auto-load `Idrepo-local.properties` when `-Denv.endpoint` contains `localhost` / `127.0.0.1`; otherwise keep using `Idrepo.properties` for remote/QA.
- Add committed `Idrepo-local.properties` for local docker-compose (WireMock `:8082`, idrepo `:8090`, Postgres `:5455`) so shared env properties are not edited for local runs.
- Document the rule in `api-test/README.md` and gitignore `.env.local` / `.env.qa11new`.

## Test plan
- [ ] Local: `-Denv.endpoint=http://localhost:8082` logs loading `Idrepo-local.properties`
- [ ] Remote: `-Denv.endpoint=https://api-internal.qa11new.mosip.net` loads `Idrepo.properties`
- [ ] Optional override `-Didrepo.propertiesFile=...` still wins
- [ ] Secrets via env / `.env.local` still override blank file values


Made with [Cursor](https://cursor.com)